### PR TITLE
add isPublic option for attachments

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn.vue
@@ -115,6 +115,28 @@
                     @input="newColumn.altered = newColumn.altered || 2"
                   />
                 </v-col>
+                <v-col v-if="isAttachment" cols="12">
+                  <v-tooltip bottom z-index="99999">
+                    <template #activator="{on}">
+                      <div v-on="on">
+                        <v-checkbox
+                          v-model="newColumn.public"
+                          :disabled="!!editColumn"
+                          class="mr-2 mt-0"
+                          dense
+                          hide-details
+                          label="AT"
+                          @input="newColumn.altered = newColumn.altered || 2"
+                        >
+                          <template #label>
+                            <span class="caption font-weight-bold">Public</span>
+                          </template>
+                        </v-checkbox>
+                      </div>
+                    </template>
+                    <span>Only works if S3 plugin is enabled.</span>
+                  </v-tooltip>
+                </v-col>
                 <v-col v-if="accordion" cols="12" class="pt-0" :class="{'pb-0': advanceOptions}">
                   <div
                     class="pointer grey--text text-right caption nc-more-options"
@@ -506,6 +528,9 @@ export default {
     },
     isVirtual() {
       return this.isLinkToAnotherRecord || this.isLookup || this.isRollup
+    },
+    isAttachment() {
+      return this.newColumn && this.newColumn.uidt === 'Attachment'
     }
   },
   watch: {

--- a/packages/nocodb/src/interface/IStorageAdapter.ts
+++ b/packages/nocodb/src/interface/IStorageAdapter.ts
@@ -1,6 +1,6 @@
 export default interface IStorageAdapter {
   init(): Promise<any>;
-  fileCreate(destPath: string, file: XcFile): Promise<any>;
+  fileCreate(destPath: string, file: XcFile, isPublic?: boolean): Promise<any>;
   fileDelete(filePath: string): Promise<any>;
   fileRead(filePath: string): Promise<any>;
   test(): Promise<boolean>;

--- a/packages/nocodb/src/lib/noco/common/BaseApiBuilder.ts
+++ b/packages/nocodb/src/lib/noco/common/BaseApiBuilder.ts
@@ -1132,6 +1132,13 @@ export default abstract class BaseApiBuilder<T extends Noco>
         newCol = newMeta.columns.find(c => c.cn === column.cn);
         if (newCol && oldCol) {
           newCol.validate = oldCol.validate;
+          if (
+            newCol.uidt === UITypes.Attachment &&
+            'public' in oldCol &&
+            'public' in newCol
+          ) {
+            newCol.public = oldCol.public;
+          }
         }
       }
     }

--- a/packages/nocodb/src/lib/noco/plugins/NcPluginMgr.ts
+++ b/packages/nocodb/src/lib/noco/plugins/NcPluginMgr.ts
@@ -116,8 +116,12 @@ class NcPluginMgr {
     return (
       (this.activePlugins?.find(
         plugin => plugin instanceof XcStoragePlugin
-      ) as XcStoragePlugin)?.getAdapter() || new Local()
+      ) as XcStoragePlugin)?.getAdapter() || this.localStorage
     );
+  }
+
+  public get localStorage(): IStorageAdapter {
+    return new Local();
   }
 
   public get emailAdapter(): IEmailAdapter {

--- a/packages/nocodb/src/plugins/s3/S3.ts
+++ b/packages/nocodb/src/plugins/s3/S3.ts
@@ -13,8 +13,10 @@ export default class S3 implements IStorageAdapter {
     this.input = input;
   }
 
-  async fileCreate(key: string, file: XcFile): Promise<any> {
-    const uploadParams: any = {};
+  async fileCreate(key: string, file: XcFile, isPublic = false): Promise<any> {
+    const uploadParams: any = {
+      ACL: isPublic ? 'public-read' : 'private'
+    };
     return new Promise((resolve, reject) => {
       // Configure the file stream and obtain the upload parameters
       const fileStream = fs.createReadStream(file.path);


### PR DESCRIPTION
## Change Summary

Add option of making S3 attachment columns public or private.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
