### PR TITLE
fix: incorrect queries when column alias is a column name in related table

### DIFF
--- a/packages/nocodb/package-lock.json
+++ b/packages/nocodb/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nocodb",
-  "version": "0.84.14-finn.3",
+  "version": "0.84.14-finn.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/BaseModelSql.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/BaseModelSql.ts
@@ -1348,9 +1348,9 @@ class BaseModelSql extends BaseModel {
         driver.union(
           parent.map(p => {
             const id =
-              p[_cn] ||
               p[this.columnToAlias?.[this.pks[0].cn] || this.pks[0].cn] ||
-              p[this.pks[0].cn];
+              p[this.pks[0].cn] ||
+              p[_cn];
             const query = driver(this.dbModels[child].tnPath)
               .where(cn, id)
               .xwhere(where, this.dbModels[child].selectQuery(''))


### PR DESCRIPTION
## Change Summary

Nocodb was taking incorrect values when column alias of a column in a table was same as column name in a related table.
It's deprioritising it the search based on column alias. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
