### PR TITLE
disable keep alive

### DIFF
--- a/packages/nocodb/docker/index.js
+++ b/packages/nocodb/docker/index.js
@@ -15,6 +15,7 @@ server.set('view engine', 'ejs');
   const httpServer = server.listen(process.env.PORT || 8080, () => {
     console.log(`App started successfully.\nVisit -> ${Noco.dashboardUrl}`);
   })
+  httpServer.keepAliveTimeout = 0; // disable keep-alive
 
   server.use(await Noco.init({}, httpServer, server));
 })().catch(e => console.log(e))


### PR DESCRIPTION
## Change Summary

To remedy increased 502s, I am disabling the keep alive of HTTP connections.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
