### PR TITLE
Noc 287 access token has same access

### DIFF
--- a/packages/nocodb/src/__tests__/unit/lib/models/ApiToken.test.ts
+++ b/packages/nocodb/src/__tests__/unit/lib/models/ApiToken.test.ts
@@ -1,0 +1,193 @@
+import { expect } from 'chai';
+import ApiToken from '../../../../lib/models/ApiToken';
+import knex from 'knex';
+import { MetaTable } from '../../../../lib/utils/globals';
+import sinon from 'sinon';
+import NcMetaIO from '../../../../lib/meta/NcMetaIO';
+import XcMigrationSource from '../../../../lib/migrations/XcMigrationSource';
+import XcMigrationSourcev2 from '../../../../lib/migrations/XcMigrationSourcev2';
+
+const qb = knex({
+  client: 'sqlite3',
+  connection: {
+    filename: ':memory:',
+  },
+  useNullAsDefault: true,
+});
+
+before(async () => {
+  await qb.migrate.latest({
+    migrationSource: new XcMigrationSource(),
+    tableName: 'xc_knex_migrations',
+  });
+  await qb.migrate.latest({
+    migrationSource: new XcMigrationSourcev2(),
+    tableName: 'xc_knex_migrationsv2',
+  });
+});
+
+describe('ApiToken', () => {
+  const mockNcMeta = sinon.mock(NcMetaIO);
+  mockNcMeta.metaList = async (
+    _project_id: string,
+    _dbAlias: string,
+    target: string,
+    args?: {
+      condition?: { [key: string]: any };
+    }
+  ) => {
+    return await qb(target)
+      .select()
+      .where(args?.condition || {});
+  };
+  mockNcMeta.metaInsert = async (
+    _project_id: string,
+    _dbAlias: string,
+    target: string,
+    data: any
+  ) => {
+    return await qb(target).insert(data);
+  };
+  mockNcMeta.metaGet = async (
+    _project_id: string,
+    _base_id: string,
+    target: string,
+    idOrCondition: string | { [key: string]: any }
+  ) => {
+    return await qb(target).select().where(idOrCondition).first();
+  };
+  mockNcMeta.metaDelete = async (
+    _project_id: string,
+    _dbAlias: string,
+    target: string,
+    idOrCondition?: string | { [key: string]: any }
+  ) => {
+    return await qb(target).where(idOrCondition).delete();
+  };
+  const ownerToken = {
+    created_at: '',
+    db_alias: '',
+    description: 'test_token_1',
+    enabled: 1,
+    expiry: '',
+    id: 1,
+    permissions: '',
+    project_id: '',
+    token: 'test_token_1',
+    updated_at: '',
+    user_id: 'owner1',
+  };
+  const userToken = {
+    description: 'test_token_2',
+    user_id: 'user1',
+    token: 'test_token_2',
+    created_at: '',
+    db_alias: '',
+    enabled: 1,
+    expiry: '',
+    id: 2,
+    permissions: '',
+    project_id: '',
+    updated_at: '',
+  };
+
+  const testTokens = [ownerToken, userToken];
+
+  beforeEach(async () => {
+    await qb(MetaTable.API_TOKENS).insert(testTokens);
+  });
+
+  afterEach(async () => {
+    await qb(MetaTable.API_TOKENS).delete();
+  });
+
+  describe('list', () => {
+    describe('when user is creator or owner', () => {
+      it('should return all tokens', async () => {
+        const userId = 'owner1';
+        const userRoles = { creator: true, owner: true };
+        const tokens = await ApiToken.list(userId, userRoles, mockNcMeta);
+        expect(tokens).to.eql(testTokens);
+      });
+    });
+
+    describe('when user is not creator or owner', () => {
+      it('should return user tokens', async () => {
+        const userId = 'user1';
+        const userRoles = { creator: false, owner: false };
+        const tokens = await ApiToken.list(userId, userRoles, mockNcMeta);
+        expect(tokens).to.eql([userToken]);
+      });
+    });
+  });
+
+  describe('insert', () => {
+    it('should insert token and return created token', async () => {
+      const token = await ApiToken.insert(
+        {
+          description: 'insert_test_token_3',
+          user_id: 'user2',
+        },
+        mockNcMeta
+      );
+      expect(token).to.have.property('description', 'insert_test_token_3');
+    });
+  });
+
+  describe('delete', () => {
+    describe('when user is creator or owner', () => {
+      const userId = 'owner1';
+      const userRoles = { creator: true, owner: true };
+      it('can delete own token', async () => {
+        const deleted = await ApiToken.delete(
+          ownerToken.token,
+          userId,
+          userRoles,
+          mockNcMeta
+        );
+        expect(deleted).to.equal(1);
+      });
+
+      it('can delete other user token', async () => {
+        const deleted = await ApiToken.delete(
+          userToken.token,
+          userId,
+          userRoles,
+          mockNcMeta
+        );
+        expect(deleted).to.equal(1);
+      });
+    });
+
+    describe('when user is not creator or owner', () => {
+      const userId = 'user1';
+      const userRoles = { creator: false, owner: false };
+      it('can delete own token', async () => {
+        const deleted = await ApiToken.delete(
+          userToken.token,
+          userId,
+          userRoles,
+          mockNcMeta
+        );
+        expect(deleted).to.equal(1);
+      });
+
+      it('can not delete other user token', async () => {
+        const deleted = await ApiToken.delete(
+          ownerToken.token,
+          userId,
+          userRoles,
+          mockNcMeta
+        );
+        expect(deleted).to.equal(0);
+      });
+    });
+  });
+
+  describe('getByToken', () => {
+    it('should return token', async () => {
+      const token = await ApiToken.getByToken(userToken.token, mockNcMeta);
+      expect(token).to.eql(userToken);
+    });
+  });
+});

--- a/packages/nocodb/src/__tests__/unit/lib/models/ProjectUser.test.ts
+++ b/packages/nocodb/src/__tests__/unit/lib/models/ProjectUser.test.ts
@@ -5,6 +5,7 @@ import NcMetaIO from '../../../../lib/meta/NcMetaIO';
 import knex from 'knex';
 import XcMigrationSourcev2 from '../../../../lib/migrations/XcMigrationSourcev2';
 import { MetaTable } from '../../../../lib/utils/globals';
+import XcMigrationSource from '../../../../lib/migrations/XcMigrationSource';
 
 const qb = knex({
   client: 'sqlite3',
@@ -15,6 +16,10 @@ const qb = knex({
 });
 
 before(async () => {
+  await qb.migrate.latest({
+    migrationSource: new XcMigrationSource(),
+    tableName: 'xc_knex_migrations',
+  });
   await qb.migrate.latest({
     migrationSource: new XcMigrationSourcev2(),
     tableName: 'xc_knex_migrationsv2',

--- a/packages/nocodb/src/lib/meta/api/apiTokenApis.ts
+++ b/packages/nocodb/src/lib/meta/api/apiTokenApis.ts
@@ -5,7 +5,12 @@ import { Tele } from 'nc-help';
 import { metaApiMetrics } from '../helpers/apiMetrics';
 
 export async function apiTokenList(req: Request, res: Response) {
-  res.json(await ApiToken.list(req['session']?.passport?.user?.id));
+  res.json(
+    await ApiToken.list(
+      req['session']?.passport?.user?.id,
+      req['session']?.passport?.user?.roles
+    )
+  );
 }
 export async function apiTokenCreate(req: Request, res: Response) {
   Tele.emit('evt', { evt_type: 'apiToken:created' });
@@ -19,7 +24,11 @@ export async function apiTokenCreate(req: Request, res: Response) {
 export async function apiTokenDelete(req: Request, res: Response) {
   Tele.emit('evt', { evt_type: 'apiToken:deleted' });
   res.json(
-    await ApiToken.delete(req.params.token, req['session']?.passport?.user?.id)
+    await ApiToken.delete(
+      req.params.token,
+      req['session']?.passport?.user?.id,
+      req['session']?.passport?.user?.roles
+    )
   );
 }
 

--- a/packages/nocodb/src/lib/meta/api/apiTokenApis.ts
+++ b/packages/nocodb/src/lib/meta/api/apiTokenApis.ts
@@ -4,16 +4,23 @@ import ApiToken from '../../models/ApiToken';
 import { Tele } from 'nc-help';
 import { metaApiMetrics } from '../helpers/apiMetrics';
 
-export async function apiTokenList(_req: Request, res: Response) {
-  res.json(await ApiToken.list());
+export async function apiTokenList(req: Request, res: Response) {
+  res.json(await ApiToken.list(req['session']?.passport?.user?.id));
 }
 export async function apiTokenCreate(req: Request, res: Response) {
   Tele.emit('evt', { evt_type: 'apiToken:created' });
-  res.json(await ApiToken.insert(req.body));
+  res.json(
+    await ApiToken.insert({
+      ...req.body,
+      user_id: req['session']?.passport?.user?.id,
+    })
+  );
 }
 export async function apiTokenDelete(req: Request, res: Response) {
   Tele.emit('evt', { evt_type: 'apiToken:deleted' });
-  res.json(await ApiToken.delete(req.params.token));
+  res.json(
+    await ApiToken.delete(req.params.token, req['session']?.passport?.user?.id)
+  );
 }
 
 const router = Router({ mergeParams: true });

--- a/packages/nocodb/src/lib/meta/helpers/ncMetaAclMw.ts
+++ b/packages/nocodb/src/lib/meta/helpers/ncMetaAclMw.ts
@@ -62,19 +62,14 @@ export default function(handlerFn, permissionName) {
           );
         });
       if (!isAllowed) {
-        const projectOwnersEmailsCommaSeperated = (
-          await ProjectUser.getOwnersList({
-            project_id: req.params.projectId,
-          })
-        )
-          .map((user) => user.email)
-          .join(',');
         NcError.forbidden(
           `${permissionName} - ${Object.keys(roles).filter(
             k => roles[k]
           )} : Not allowed.${
             permissionName === 'projectGet'
-              ? ` Please contact ${projectOwnersEmailsCommaSeperated} for access.`
+              ? ` Please contact ${await ProjectUser.getOwnersEmailsCSV(
+                  req.params.projectId
+                )} for access.`
               : ''
           }`
         );

--- a/packages/nocodb/src/lib/migrations/XcMigrationSourcev2.ts
+++ b/packages/nocodb/src/lib/migrations/XcMigrationSourcev2.ts
@@ -8,6 +8,7 @@ import * as nc_016_alter_hooklog_payload_types from './v2/nc_016_alter_hooklog_p
 import * as nc_017_add_user_token_version_column from './v2/nc_017_add_user_token_version_column';
 import * as nc_018_remove_user_token_version_column from './v2/nc_018_remove_user_token_version_column';
 import * as nc_019_cascade_relations_metadata from './v2/nc_019_cascade_relations_metadata';
+import * as nc_020_add_user_id_in_nc_api_tokens from './v2/nc_020_add_user_id_in_nc_api_tokens';
 
 // Create a custom migration source class
 export default class XcMigrationSourcev2 {
@@ -27,6 +28,7 @@ export default class XcMigrationSourcev2 {
       'nc_017_add_user_token_version_column',
       'nc_018_remove_user_token_version_column',
       'nc_019_cascade_relations_metadata',
+      'nc_020_add_user_id_in_nc_api_tokens',
     ]);
   }
 
@@ -56,6 +58,8 @@ export default class XcMigrationSourcev2 {
         return nc_018_remove_user_token_version_column;
       case 'nc_019_cascade_relations_metadata':
         return nc_019_cascade_relations_metadata;
+      case 'nc_020_add_user_id_in_nc_api_tokens':
+        return nc_020_add_user_id_in_nc_api_tokens;
     }
   }
 }

--- a/packages/nocodb/src/lib/migrations/v2/nc_020_add_user_id_in_nc_api_tokens.ts
+++ b/packages/nocodb/src/lib/migrations/v2/nc_020_add_user_id_in_nc_api_tokens.ts
@@ -1,0 +1,37 @@
+import Knex from 'knex';
+
+const up = async knex => {
+  await knex.schema.alterTable('nc_api_tokens', table => {
+    table.string('user_id');
+  });
+};
+
+const down = async (knex: Knex) => {
+  await knex.schema.alterTable('nc_api_tokens', table => {
+    table.dropColumns('user_id');
+  });
+};
+
+export { up, down };
+
+/**
+ * @copyright Copyright (c) 2021, Xgene Cloud Ltd
+ *
+ * @author Wing-Kam Wong <wingkwong.code@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */

--- a/packages/nocodb/src/lib/models/ApiToken.ts
+++ b/packages/nocodb/src/lib/models/ApiToken.ts
@@ -16,6 +16,7 @@ export default class ApiToken {
   token?: string;
   expiry?: string;
   enabled?: boolean;
+  user_id?: string;
 
   constructor(audit: Partial<ApiToken>) {
     Object.assign(this, audit);

--- a/packages/nocodb/src/lib/models/ApiToken.ts
+++ b/packages/nocodb/src/lib/models/ApiToken.ts
@@ -1,12 +1,6 @@
-import {
-  CacheDelDirection,
-  CacheGetType,
-  CacheScope,
-  MetaTable
-} from '../utils/globals';
+import { MetaTable } from '../utils/globals';
 import Noco from '../Noco';
 import { nanoid } from 'nanoid';
-import NocoCache from '../cache/NocoCache';
 
 export default class ApiToken {
   project_id?: string;
@@ -31,42 +25,22 @@ export default class ApiToken {
       description: apiToken.description,
       token
     });
-    await NocoCache.appendToList(
-      CacheScope.API_TOKEN,
-      [],
-      `${CacheScope.API_TOKEN}:${token}`
-    );
     return this.getByToken(token);
   }
 
   static async list(ncMeta = Noco.ncMeta) {
-    let tokens = await NocoCache.getList(CacheScope.API_TOKEN, []);
-    if (!tokens.length) {
-      tokens = await ncMeta.metaList(null, null, MetaTable.API_TOKENS);
-      await NocoCache.setList(CacheScope.API_TOKEN, [], tokens);
-    }
+    const tokens = await ncMeta.metaList(null, null, MetaTable.API_TOKENS);
     return tokens?.map(t => new ApiToken(t));
   }
+
   static async delete(token, ncMeta = Noco.ncMeta) {
-    await NocoCache.deepDel(
-      CacheScope.API_TOKEN,
-      `${CacheScope.API_TOKEN}:${token}`,
-      CacheDelDirection.CHILD_TO_PARENT
-    );
     return await ncMeta.metaDelete(null, null, MetaTable.API_TOKENS, { token });
   }
 
   static async getByToken(token, ncMeta = Noco.ncMeta) {
-    let data =
-      token &&
-      (await NocoCache.get(
-        `${CacheScope.API_TOKEN}:${token}`,
-        CacheGetType.TYPE_OBJECT
-      ));
-    if (!data) {
-      data = await ncMeta.metaGet(null, null, MetaTable.API_TOKENS, { token });
-      await NocoCache.set(`${CacheScope.API_TOKEN}:${token}`, data);
-    }
+    const data = await ncMeta.metaGet(null, null, MetaTable.API_TOKENS, {
+      token,
+    });
     return data && new ApiToken(data);
   }
 }

--- a/packages/nocodb/src/lib/models/ApiToken.ts
+++ b/packages/nocodb/src/lib/models/ApiToken.ts
@@ -23,23 +23,30 @@ export default class ApiToken {
     const token = nanoid(40);
     await ncMeta.metaInsert(null, null, MetaTable.API_TOKENS, {
       description: apiToken.description,
+      user_id: apiToken?.user_id,
       token
     });
-    return this.getByToken(token);
+    return this.getByToken(token, apiToken?.user_id);
   }
 
-  static async list(ncMeta = Noco.ncMeta) {
-    const tokens = await ncMeta.metaList(null, null, MetaTable.API_TOKENS);
+  static async list(userId = null, ncMeta = Noco.ncMeta) {
+    const tokens = await ncMeta.metaList(null, null, MetaTable.API_TOKENS, {
+      condition: { user_id: userId },
+    });
     return tokens?.map(t => new ApiToken(t));
   }
 
-  static async delete(token, ncMeta = Noco.ncMeta) {
-    return await ncMeta.metaDelete(null, null, MetaTable.API_TOKENS, { token });
+  static async delete(token, userId = null, ncMeta = Noco.ncMeta) {
+    return await ncMeta.metaDelete(null, null, MetaTable.API_TOKENS, {
+      token,
+      user_id: userId,
+    });
   }
 
-  static async getByToken(token, ncMeta = Noco.ncMeta) {
+  static async getByToken(token, userId = null, ncMeta = Noco.ncMeta) {
     const data = await ncMeta.metaGet(null, null, MetaTable.API_TOKENS, {
       token,
+      user_id: userId,
     });
     return data && new ApiToken(data);
   }

--- a/packages/nocodb/src/lib/models/ProjectUser.ts
+++ b/packages/nocodb/src/lib/models/ProjectUser.ts
@@ -108,6 +108,12 @@ export default class ProjectUser {
     return await queryBuilder;
   }
 
+  public static async getOwnersEmailsCSV(projectId, ncMeta = Noco.ncMeta) {
+    return this.getOwnersList({ project_id: projectId }, ncMeta).then((users) =>
+      users.map((user) => user.email).join(',')
+    );
+  }
+
   public static async getOwnersList(
     {
       project_id,

--- a/packages/nocodb/src/lib/utils/projectAcl.ts
+++ b/packages/nocodb/src/lib/utils/projectAcl.ts
@@ -133,7 +133,9 @@ export default {
     relationDataAdd: true,
     dataCount: true,
     upload: true,
-    uploadViaURL: true
+    uploadViaURL: true,
+    apiTokenCreate: true,
+    apiTokenList: true,
   },
   commenter: {
     formViewGet: true,
@@ -186,7 +188,9 @@ export default {
     xcAuditCommentInsert: true,
     xcAuditModelCommentsCount: true,
     xcExportAsCsv: true,
-    dataCount: true
+    dataCount: true,
+    apiTokenCreate: true,
+    apiTokenList: true,
   },
   viewer: {
     formViewGet: true,
@@ -234,7 +238,9 @@ export default {
     indexList: true,
     list: true,
     xcExportAsCsv: true,
-    dataCount: true
+    dataCount: true,
+    apiTokenCreate: true,
+    apiTokenList: true,
   },
   user_new: {
     passwordChange: true,


### PR DESCRIPTION
## Change Summary

There are 2 commits, 
 1. for adding a user role when accessing API with the token.
 2. refactored project user ACL, it was giving SQL error in forbidden API requests with `xc-token`.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [x] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
