### PR TITLE
validate except primary key for bulk update

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
@@ -1611,6 +1611,13 @@ class BaseModelSqlv2 {
     }
   }
 
+  deletePrimaryKeyFromData(data) {
+    const { primaryKey } = this.model;
+    if (primaryKey) {
+      delete data[primaryKey.title];
+    }
+  }
+
   async bulkUpdate(datas: any[]) {
     let transaction;
     try {
@@ -1623,12 +1630,14 @@ class BaseModelSqlv2 {
       // await this.beforeUpdateb(updateDatas, transaction);
       const res = [];
       for (const d of updateDatas) {
-        await this.validate(d);
         const pkValues = await this._extractPksValues(d);
         if (!pkValues) {
           // pk not specified - bypass
           continue;
         }
+        // removing primary key from data because it's not an updateable column
+        this.deletePrimaryKeyFromData(d);
+        await this.validate(d);
         const wherePk = await this._wherePk(pkValues);
         const response = await transaction(this.model.table_name)
           .update(d)


### PR DESCRIPTION
## Change Summary

Since the last change in blocking system columns from the update, the bulk update was failing as it sends the primary key in the data. This fix removes the primary key from data before validating it.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
