### PR TITLE
NOC-243: add filter inputs

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/RowsXcDataTable.vue
+++ b/packages/nc-gui/components/project/spreadsheet/RowsXcDataTable.vue
@@ -73,6 +73,7 @@
             :field-list="[...realFieldList, ...formulaFieldList]"
             dense
             :view-id="selectedViewId"
+            :sql-ui="sqlUi"
             @updated="loadTableData(false)"
           />
           <sort-list

--- a/packages/nc-gui/components/project/spreadsheet/components/ColumnFilterMenu.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/ColumnFilterMenu.vue
@@ -24,6 +24,7 @@
     <column-filter
       ref="filter"
       v-model="filters"
+      :sqlUi="sqlUi"
       :shared="shared"
       :view-id="viewId"
       :field-list="fieldList"
@@ -63,7 +64,7 @@ import ColumnFilter from '~/components/project/spreadsheet/components/ColumnFilt
 export default {
   name: 'ColumnFilterMenu',
   components: { ColumnFilter },
-  props: ['fieldList', 'isLocked', 'value', 'meta', 'viewId', 'shared'],
+  props: ['fieldList', 'isLocked', 'value', 'meta', 'viewId', 'shared', 'sqlUi'],
   data: () => ({
     filters: [],
   }),

--- a/packages/nc-gui/components/project/spreadsheet/components/FieldListAutoCompleteDropdown.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/FieldListAutoCompleteDropdown.vue
@@ -20,7 +20,7 @@
       </v-icon>
     </template>
     <template #item="{ item }">
-      <span :class="`caption font-weight-regular nc-fld-${item.title}`">
+      <span :class="`caption font-weight-regular nc-fld-${item.title.split(' ').join('')}`">
         <v-icon color="grey" small class="mr-1">
           {{ item.icon }}
         </v-icon>

--- a/packages/nc-gui/components/project/spreadsheet/components/filterValueInput/BooleanType.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/filterValueInput/BooleanType.vue
@@ -1,0 +1,22 @@
+<template>
+  <v-select v-model="localState" solo dense flat :items="[true, false]" hide-details class="mt-0" />
+</template>
+
+<script>
+export default {
+  name: 'BooleanType',
+  props: {
+    value: Boolean,
+  },
+  computed: {
+    localState: {
+      get() {
+        return this.value;
+      },
+      set(value) {
+        this.$emit('input', value);
+      },
+    },
+  },
+};
+</script>

--- a/packages/nc-gui/components/project/spreadsheet/components/filterValueInput/FilterValueInput.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/filterValueInput/FilterValueInput.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="backgroundColorDefault d-flex align-center justify-center" :class="{ 'px-3': !isDateTime }">
+    <component
+      :is="$options.componentMap[filterType]"
+      v-model="localState"
+      :column="column"
+      class="d-flex align-center"
+      ignore-focus
+    />
+  </div>
+</template>
+
+<script>
+import BooleanType from './BooleanType';
+import cell from '~/components/project/spreadsheet/mixins/cell';
+import RatingCell from '~/components/project/spreadsheet/components/editableCell/RatingCell';
+import EditableUrlCell from '~/components/project/spreadsheet/components/editableCell/EditableUrlCell';
+import SetListEditableCell from '~/components/project/spreadsheet/components/editableCell/SetListEditableCell';
+import TimePickerCell from '~/components/project/spreadsheet/components/editableCell/TimePickerCell';
+import FloatCell from '~/components/project/spreadsheet/components/editableCell/FloatCell';
+import IntegerCell from '~/components/project/spreadsheet/components/editableCell/IntegerCell';
+import EnumListCell from '~/components/project/spreadsheet/components/editableCell/EnumListEditableCell';
+import DateTimePickerCell from '~/components/project/spreadsheet/components/editableCell/DateTimePickerCell';
+import TextCell from '~/components/project/spreadsheet/components/editableCell/TextCell';
+import DatePickerCell from '~/components/project/spreadsheet/components/editableCell/DatePickerCell';
+import DurationCell from '~/components/project/spreadsheet/components/editableCell/DurationCell';
+
+export default {
+  name: 'FilterValueInput',
+  components: {
+    RatingCell,
+    EditableUrlCell,
+    SetListEditableCell,
+    TimePickerCell,
+    FloatCell,
+    IntegerCell,
+    EnumListCell,
+    DateTimePickerCell,
+    TextCell,
+    DatePickerCell,
+    DurationCell,
+  },
+  mixins: [cell],
+  props: {
+    value: null,
+    sqlUi: [Object, Function],
+    column: Object,
+  },
+  componentMap: {
+    isRating: RatingCell,
+    isDuration: DurationCell,
+    isInt: IntegerCell,
+    isFloat: FloatCell,
+    isDate: DatePickerCell,
+    isBoolean: BooleanType,
+    isTime: TimePickerCell,
+    isDateTime: DateTimePickerCell,
+    isEnum: EnumListCell,
+    isSet: SetListEditableCell,
+    isUrl: EditableUrlCell,
+    default: TextCell,
+  },
+  computed: {
+    localState: {
+      get() {
+        return this.value;
+      },
+      set(value) {
+        this.$emit('input', value);
+      },
+    },
+    filterType() {
+      return Object.keys(this.$options.componentMap).find(key => this[key]) || 'default';
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/packages/nc-gui/layouts/default.vue
+++ b/packages/nc-gui/layouts/default.vue
@@ -306,6 +306,7 @@ export default {
       );
     },
     ...mapGetters({
+      brandName: 'plugins/brandName',
       projects: 'project/list',
       tabs: 'tabs/list',
       sqldMgr: 'sqlMgr/sqlMgr',


### PR DESCRIPTION
## Change Summary

Current implementation: in auto apply mode filters are only saved and applied when filter has some value. (except for null, not null, empty, not empty). 

When filter type is changed for already existing value, the value is reset to null (to avoid errors like string value in id field)

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
