### PR TITLE
NOC-325: fix for camelization

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/EditColumn.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/EditColumn.vue
@@ -649,6 +649,7 @@ export default {
       if (!this.$refs.form.validate()) {
         return;
       }
+
       try {
         if (this.newColumn.uidt === 'Formula') {
           await this.$refs.formula.save();
@@ -671,7 +672,11 @@ export default {
         }
 
         this.newColumn.table_name = this.nodes.table_name;
-        this.newColumn.title = this.newColumn.column_name;
+
+        // condition is needed not to break camelization when column name is not changed
+        if (this.newColumn.column_name !== this.column.column_name) {
+          this.newColumn.title = this.newColumn.column_name;
+        }
 
         if (this.editColumn) {
           await this.$api.dbTableColumn.update(this.column.id, this.newColumn);


### PR DESCRIPTION
## Change Summary

Camelization is something that is made once and on the backend, there is no title formatting on frontend.

1st idea was to disable save button if form hasn't changed, but it doesn't work with type changes like TypeA -> TypeB -> TypeA, because some column params are unexpectedly changed like false -> 0 etc, while meaning the same, makes more difficult to understand that something has really changed.

That's why as a quick hack decided to reset title only if column_name changed

TBD (not in this task): consider "camelizing" policy not only for table import, but also afterwards? (discuss with users)

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
