### PR TITLE
NOC-380: fix team tab

### DIFF
--- a/packages/nc-gui/components/dashboard/settings/Modal.vue
+++ b/packages/nc-gui/components/dashboard/settings/Modal.vue
@@ -40,7 +40,8 @@ const { t } = useI18n()
 
 const { $e } = useNuxtApp()
 
-const tabsInfo: TabGroup = {
+const tabsInfo = $computed<TabGroup>(() =>
+  ({
   teamAndAuth: {
     title: t('title.teamAndAuth'),
     icon: TeamFillIcon,
@@ -135,14 +136,15 @@ const tabsInfo: TabGroup = {
       $e('c:settings:audit')
     },
   },
-}
+}));
+
 const firstKeyOfObject = (obj: object) => Object.keys(obj)[0]
 
 // Array of keys of tabs which are selected. In our case will be only one.
-let selectedTabKeys = $ref<string[]>([firstKeyOfObject(tabsInfo)])
+let selectedTabKeys = $computed<string[]>(() => [firstKeyOfObject(tabsInfo)])
 const selectedTab = $computed(() => tabsInfo[selectedTabKeys[0]])
 
-let selectedSubTabKeys = $ref<string[]>([firstKeyOfObject(selectedTab.subTabs)])
+let selectedSubTabKeys = $computed<string[]>(() => [firstKeyOfObject(selectedTab.subTabs)])
 const selectedSubTab = $computed(() => selectedTab.subTabs[selectedSubTabKeys[0]])
 
 watch(
@@ -158,6 +160,7 @@ watch(
     selectedTabKeys = [Object.keys(tabsInfo).find((key) => key === nextOpenKey) || firstKeyOfObject(tabsInfo)]
   },
 )
+
 </script>
 
 <template>


### PR DESCRIPTION
## Change Summary

Because tabs in settings are not reactive and it depends on some data, that is loaded async,
it leads to screen being empty

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
