### PR TITLE
NOC-391: fix permissions for settings tab

### DIFF
--- a/packages/nc-gui/components/dashboard/settings/Modal.vue
+++ b/packages/nc-gui/components/dashboard/settings/Modal.vue
@@ -40,9 +40,10 @@ const { t } = useI18n()
 
 const { $e } = useNuxtApp()
 
+
 const tabsInfo = $computed<TabGroup>(() =>
   ({
-  teamAndAuth: {
+    ...(isUIAllowed('teamAndAuth') ? { teamAndAuth: {
     title: t('title.teamAndAuth'),
     icon: TeamFillIcon,
     subTabs: {
@@ -86,8 +87,8 @@ const tabsInfo = $computed<TabGroup>(() =>
           },
         },
       }
-    : {}),
-  projMetaData: {
+    : {}) } : {}),
+  ...(isUIAllowed('projMetaData') ? { projMetaData: {
     // Project Metadata
     title: t('title.projMeta'),
     icon: MultipleTableIcon,
@@ -120,8 +121,8 @@ const tabsInfo = $computed<TabGroup>(() =>
     onClick: () => {
       $e('c:settings:proj-metadata')
     },
-  },
-  audit: {
+  }} : {}),
+    ...(isUIAllowed('audit') ? { audit: {
     // Audit
     title: t('title.audit'),
     icon: NotebookOutline,
@@ -135,25 +136,25 @@ const tabsInfo = $computed<TabGroup>(() =>
     onClick: () => {
       $e('c:settings:audit')
     },
-  },
+  }} : {}),
 }));
 
 const firstKeyOfObject = (obj: object) => Object.keys(obj)[0]
 
 // Array of keys of tabs which are selected. In our case will be only one.
 let selectedTabKeys = $ref<string[]>([firstKeyOfObject(tabsInfo)])
-const selectedTab = $computed(() => tabsInfo[selectedTabKeys[0]])
+const selectedTab = $computed(() => tabsInfo[selectedTabKeys?.[0]])
 
-let selectedSubTabKeys = $ref<string[]>([firstKeyOfObject(selectedTab.subTabs)])
-const selectedSubTab = $computed(() => selectedTab.subTabs[selectedSubTabKeys[0]])
+let selectedSubTabKeys = $ref<string[]>([firstKeyOfObject(selectedTab?.subTabs ?? {})])
+const selectedSubTab = $computed(() => selectedTab?.subTabs[selectedSubTabKeys?.[0]])
 
 watch(
-  [() => tabsInfo, () => selectedTabKeys[0]],
+  [() => tabsInfo, () => selectedTabKeys?.[0]],
   ([tabsInfo, newTabKey]) => {
     if (!newTabKey || !tabsInfo?.[newTabKey]) {
       return
     }
-    selectedSubTabKeys = [firstKeyOfObject(tabsInfo[newTabKey].subTabs)]
+    selectedSubTabKeys = [firstKeyOfObject(tabsInfo[newTabKey]?.subTabs ?? {})]
   },
 )
 
@@ -205,11 +206,11 @@ watch(
             :key="key"
             class="group active:(!ring-0) hover:(!bg-primary !bg-opacity-25)"
           >
-            <div class="flex items-center space-x-2" @click="tab.onClick">
-              <component :is="tab.icon" class="group-hover:text-accent" />
+            <div class="flex items-center space-x-2" @click="tab?.onClick">
+              <component :is="tab?.icon" class="group-hover:text-accent" />
 
               <div class="select-none">
-                {{ tab.title }}
+                {{ tab?.title }}
               </div>
             </div>
           </a-menu-item>
@@ -220,16 +221,16 @@ watch(
       <a-layout-content class="h-auto px-4 scrollbar-thumb-gray-500">
         <a-menu v-model:selectedKeys="selectedSubTabKeys" :open-keys="[]" mode="horizontal">
           <a-menu-item
-            v-for="(tab, key) of selectedTab.subTabs"
+            v-for="(tab, key) of selectedTab?.subTabs"
             :key="key"
             class="active:(!ring-0) select-none"
-            @click="tab.onClick"
+            @click="tab?.onClick"
           >
-            {{ tab.title }}
+            {{ tab?.title }}
           </a-menu-item>
         </a-menu>
 
-        <component :is="selectedSubTab?.body" class="px-2 py-6" :data-nc="`nc-settings-subtab-${selectedSubTab.title}`" />
+        <component :is="selectedSubTab?.body" class="px-2 py-6" :data-nc="`nc-settings-subtab-${selectedSubTab?.title}`" />
       </a-layout-content>
     </a-layout>
   </a-modal>

--- a/packages/nc-gui/components/tabs/Auth.vue
+++ b/packages/nc-gui/components/tabs/Auth.vue
@@ -6,6 +6,7 @@ interface Tab {
   title: string
   label: string
   isUIAllowed: ComputedRef<boolean>
+  key: string
 }
 
 const { t } = useI18n()
@@ -17,23 +18,25 @@ const tabsInfo: Tab[] = [
     title: 'Users Management',
     label: t('title.userMgmt'),
     isUIAllowed: computed(() => isUIAllowed('userMgmtTab')),
+    key: 'userMgmtTab'
   },
   {
     title: 'API Token Management',
     label: t('title.apiTokenMgmt'),
     isUIAllowed: computed(() => isUIAllowed('apiTokenTab')),
+    key: 'apiTokenTab'
   },
 ]
 
-const selectedTabKey = $ref(0)
+const visibleTabs = $computed(() => tabsInfo.filter(tab => tab.isUIAllowed.value))
 
-const selectedTab = $computed(() => tabsInfo[selectedTabKey])
+const selectedTabKey = $ref(visibleTabs?.[0].key)
+
 </script>
 
-<template>
-  <div v-if="selectedTab.isUIAllowed">
+<template v-if="visibleTabs.length > 0">
     <a-tabs v-model:active-key="selectedTabKey" :open-keys="[]" mode="horizontal" class="nc-auth-tabs !mx-6">
-      <a-tab-pane v-for="(tab, key) of tabsInfo" :key="key" class="select-none">
+      <a-tab-pane v-for="(tab) of visibleTabs" :key="tab.key" class="select-none">
         <template #tab>
           <span>
             {{ tab.label }}
@@ -43,15 +46,14 @@ const selectedTab = $computed(() => tabsInfo[selectedTabKey])
     </a-tabs>
 
     <div class="mx-4 py-6 mt-2">
-      <template v-if="selectedTabKey === 0">
+      <template v-if="selectedTabKey === 'userMgmtTab'">
         <LazyTabsAuthUserManagement />
       </template>
 
-      <template v-else>
+      <template v-else-if="selectedTabKey === 'apiTokenTab'">
         <LazyTabsAuthApiTokenManagement />
       </template>
     </div>
-  </div>
 </template>
 
 <style scoped>

--- a/packages/nc-gui/lib/constants.ts
+++ b/packages/nc-gui/lib/constants.ts
@@ -56,7 +56,10 @@ export const rolePermissions = {
       apiDocs: true,
       projectSettings: true,
       newUser: false,
-      virtualViewsCreateOrEdit: true
+      virtualViewsCreateOrEdit: true,
+      settings: true,
+      apiTokenTab: true,
+      teamAndAuth: true
     },
   },
   [ProjectRole.Commenter]: {
@@ -77,6 +80,9 @@ export const rolePermissions = {
       virtualViewsCreateOrEdit: true,
       sortSync: true,
       fieldsSync: true,
+      settings: true,
+      apiTokenTab: true,
+      teamAndAuth: true
     },
   },
 } as const

--- a/packages/nocodb/src/lib/utils/projectAcl.ts
+++ b/packages/nocodb/src/lib/utils/projectAcl.ts
@@ -158,6 +158,7 @@ export default {
       uploadViaURL: true,
       apiTokenCreate: true,
       apiTokenList: true,
+      apiTokenDelete: true,
 
       gridViewCreate: true
     },
@@ -287,6 +288,7 @@ export default {
       dataCount: true,
       apiTokenCreate: true,
       apiTokenList: true,
+      apiTokenDelete: true,
 
       /* filters */
       filterCreate: true,


### PR DESCRIPTION
## Change Summary

The Viewer/Editor role in NocoDB cannot navigate the token management screen. They need to use the screen to add/copy/use auth tokens for APIs and Make App.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
