### PR TITLE
TOOL-63: fix multiselect

### DIFF
--- a/packages/nc-gui/components/smartsheet/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/Cell.vue
@@ -161,6 +161,7 @@ const syncAndNavigate = (dir: NavigateDir, e: KeyboardEvent) => {
         v-if="(isLocked || (isPublic && readOnly && !isForm) || isSystemColumn(column)) && !isAttachment(column)"
         class="nc-locked-overlay"
         @click.stop.prevent
+        @dblclick.stop.prevent
       />
     </template>
   </div>

--- a/packages/nc-gui/components/smartsheet/Grid.vue
+++ b/packages/nc-gui/components/smartsheet/Grid.vue
@@ -32,7 +32,6 @@ import {
   onMounted,
   provide,
   ref,
-  useCopy,
   useEventListener,
   useGridViewColumnWidth,
   useI18n,
@@ -53,7 +52,6 @@ const { t } = useI18n()
 const meta = inject(MetaInj, ref())
 
 const view = inject(ActiveViewInj, ref())
-const { copy } = useCopy()
 
 const { $e } = useNuxtApp()
 
@@ -173,7 +171,7 @@ const getContainerScrollForElement = (
   return scroll
 }
 
-const { selectCell, startSelectRange, endSelectRange, clearSelectedRange, copyValue, isCellSelected, selectedCell } =
+const { isCellSelected, activeCell, handleMouseDown, handleMouseOver, handleCellClick, clearSelectedRange, copyValue } =
   useMultiSelect(
     meta,
     fields,
@@ -202,9 +200,9 @@ const { selectCell, startSelectRange, endSelectRange, clearSelectedRange, copyVa
       const cmdOrCtrl = isMac() ? e.metaKey : e.ctrlKey
       const altOrOptionKey = e.altKey
       if (e.key === ' ') {
-        if (selectedCell.row !== null && !editEnabled) {
+        if (activeCell.row != null && !editEnabled) {
           e.preventDefault()
-          const row = data.value[selectedCell.row]
+          const row = data.value[activeCell.row]
           expandForm(row)
           return true
         }
@@ -229,32 +227,32 @@ const { selectCell, startSelectRange, endSelectRange, clearSelectedRange, copyVa
           case 'ArrowUp':
             e.preventDefault()
             $e('c:shortcut', { key: 'CTRL + ArrowUp' })
-            selectedCell.row = 0
-            selectedCell.col = selectedCell.col ?? 0
+            activeCell.row = 0
+            activeCell.col = activeCell.col ?? 0
             scrollToCell?.()
             editEnabled = false
             return true
           case 'ArrowDown':
             e.preventDefault()
             $e('c:shortcut', { key: 'CTRL + ArrowDown' })
-            selectedCell.row = data.value.length - 1
-            selectedCell.col = selectedCell.col ?? 0
+            activeCell.row = data.value.length - 1
+            activeCell.col = activeCell.col ?? 0
             scrollToCell?.()
             editEnabled = false
             return true
           case 'ArrowRight':
             e.preventDefault()
             $e('c:shortcut', { key: 'CTRL + ArrowRight' })
-            selectedCell.row = selectedCell.row ?? 0
-            selectedCell.col = fields.value?.length - 1
+            activeCell.row = activeCell.row ?? 0
+            activeCell.col = fields.value?.length - 1
             scrollToCell?.()
             editEnabled = false
             return true
           case 'ArrowLeft':
             e.preventDefault()
             $e('c:shortcut', { key: 'CTRL + ArrowLeft' })
-            selectedCell.row = selectedCell.row ?? 0
-            selectedCell.col = 0
+            activeCell.row = activeCell.row ?? 0
+            activeCell.col = 0
             scrollToCell?.()
             editEnabled = false
             return true
@@ -284,7 +282,7 @@ const { selectCell, startSelectRange, endSelectRange, clearSelectedRange, copyVa
     },
     async (ctx: { row: number; col?: number; updatedColumnTitle?: string }) => {
       const rowObj = data.value[ctx.row]
-      const columnObj = ctx.col !== null && ctx.col !== undefined ? fields.value[ctx.col] : null
+      const columnObj = ctx.col != null ? fields.value[ctx.col] : null
 
       if (!ctx.updatedColumnTitle && isVirtualCol(columnObj)) {
         return
@@ -296,10 +294,10 @@ const { selectCell, startSelectRange, endSelectRange, clearSelectedRange, copyVa
   )
 
 function scrollToCell(row?: number | null, col?: number | null) {
-  row = row ?? selectedCell.row
-  col = col ?? selectedCell.col
+  row = row ?? activeCell.row
+  col = col ?? activeCell.col
 
-  if (row !== undefined && col !== undefined && row !== null && col !== null) {
+  if (row != null && col != null) {
     // get active cell
     const rows = tbodyEl.value?.querySelectorAll('tr')
     const cols = rows?.[row].querySelectorAll('td')
@@ -460,13 +458,13 @@ useEventListener(document, 'keyup', async (e: KeyboardEvent) => {
 
 /** On clicking outside of table reset active cell  */
 const smartTable = ref(null)
-onClickOutside(smartTable, (e) => {
-  // do nothing if context menu was open
-  if (contextMenu.value) return
-  clearSelectedRange()
-  if (selectedCell.col === null) return
 
-  const activeCol = fields.value[selectedCell.col]
+onClickOutside(smartTable, (e) => {
+  if (contextMenu.value) return
+
+  if (activeCell.row == null || activeCell.col == null) return
+
+  const activeCol = fields.value[activeCell.col]
 
   if (editEnabled && (isVirtualCol(activeCol) || activeCol.uidt === UITypes.JSON)) return
 
@@ -487,25 +485,29 @@ onClickOutside(smartTable, (e) => {
     return
   }
 
-  selectedCell.row = null
-  selectedCell.col = null
+  clearSelectedRange()
+  activeCell.row = null
+  activeCell.col = null
 })
 
 const onNavigate = (dir: NavigateDir) => {
-  if (selectedCell.row === null || selectedCell.col === null) return
+  if (activeCell.row == null || activeCell.col == null) return
+
   editEnabled = false
+  clearSelectedRange()
+
   switch (dir) {
     case NavigateDir.NEXT:
-      if (selectedCell.row < data.value.length - 1) {
-        selectedCell.row++
+      if (activeCell.row < data.value.length - 1) {
+        activeCell.row++
       } else {
         addEmptyRow()
-        selectedCell.row++
+        activeCell.row++
       }
       break
     case NavigateDir.PREV:
-      if (selectedCell.row > 0) {
-        selectedCell.row--
+      if (activeCell.row > 0) {
+        activeCell.row--
       }
       break
   }
@@ -787,10 +789,10 @@ const closeAddColumnDropdown = () => {
                     :data-key="rowIndex + columnObj.id"
                     :data-col="columnObj.id"
                     :data-title="columnObj.title"
-                    @click="selectCell(rowIndex, colIndex)"
+                    @mousedown="handleMouseDown($event, rowIndex, colIndex)"
+                    @mouseover="handleMouseOver(rowIndex, colIndex)"
+                    @click="handleCellClick($event, rowIndex, colIndex)"
                     @dblclick="makeEditable(row, columnObj)"
-                    @mousedown="startSelectRange($event, rowIndex, colIndex)"
-                    @mouseover="endSelectRange(rowIndex, colIndex)"
                     @contextmenu="showContextMenu($event, { row: rowIndex, col: colIndex })"
                   >
                     <div v-if="!switchingTab" class="w-full h-full">
@@ -798,7 +800,7 @@ const closeAddColumnDropdown = () => {
                         v-if="isVirtualCol(columnObj)"
                         v-model="row.row[columnObj.title]"
                         :column="columnObj"
-                        :active="selectedCell.col === colIndex && selectedCell.row === rowIndex"
+                        :active="activeCell.col === colIndex && activeCell.row === rowIndex"
                         :row="row"
                         @navigate="onNavigate"
                       />
@@ -808,10 +810,10 @@ const closeAddColumnDropdown = () => {
                         v-model="row.row[columnObj.title]"
                         :column="columnObj"
                         :edit-enabled="
-                          !!hasEditPermission && !!editEnabled && selectedCell.col === colIndex && selectedCell.row === rowIndex
+                          !!hasEditPermission && !!editEnabled && activeCell.col === colIndex && activeCell.row === rowIndex
                         "
                         :row-index="rowIndex"
-                        :active="selectedCell.col === colIndex && selectedCell.row === rowIndex"
+                        :active="activeCell.col === colIndex && activeCell.row === rowIndex"
                         @update:edit-enabled="editEnabled = $event"
                         @save="updateOrSaveRow(row, columnObj.title, state)"
                         @navigate="onNavigate"
@@ -877,7 +879,7 @@ const closeAddColumnDropdown = () => {
               </div>
             </a-menu-item>
 
-            <a-menu-item v-if="contextMenuTarget" @click="copyValue(contextMenuTarget)">
+            <a-menu-item v-if="contextMenuTarget" data-testid="context-menu-item-copy" @click="copyValue(contextMenuTarget)">
               <div v-e="['a:row:copy']" class="nc-project-menu-item">
                 <!-- Copy -->
                 {{ $t('general.copy') }}

--- a/packages/nc-gui/components/smartsheet/Grid.vue
+++ b/packages/nc-gui/components/smartsheet/Grid.vue
@@ -200,8 +200,9 @@ const { isCellSelected, activeCell, handleMouseDown, handleMouseOver, handleCell
       const cmdOrCtrl = isMac() ? e.metaKey : e.ctrlKey
       const altOrOptionKey = e.altKey
       if (e.key === ' ') {
-        if (activeCell.row != null && !editEnabled) {
+        if (activeCell.row !== null && !editEnabled) {
           e.preventDefault()
+          clearSelectedRange()
           const row = data.value[activeCell.row]
           expandForm(row)
           return true
@@ -226,6 +227,7 @@ const { isCellSelected, activeCell, handleMouseDown, handleMouseOver, handleCell
         switch (e.key) {
           case 'ArrowUp':
             e.preventDefault()
+            clearSelectedRange()
             $e('c:shortcut', { key: 'CTRL + ArrowUp' })
             activeCell.row = 0
             activeCell.col = activeCell.col ?? 0
@@ -234,6 +236,7 @@ const { isCellSelected, activeCell, handleMouseDown, handleMouseOver, handleCell
             return true
           case 'ArrowDown':
             e.preventDefault()
+            clearSelectedRange()
             $e('c:shortcut', { key: 'CTRL + ArrowDown' })
             activeCell.row = data.value.length - 1
             activeCell.col = activeCell.col ?? 0
@@ -242,6 +245,7 @@ const { isCellSelected, activeCell, handleMouseDown, handleMouseOver, handleCell
             return true
           case 'ArrowRight':
             e.preventDefault()
+            clearSelectedRange()
             $e('c:shortcut', { key: 'CTRL + ArrowRight' })
             activeCell.row = activeCell.row ?? 0
             activeCell.col = fields.value?.length - 1
@@ -250,6 +254,7 @@ const { isCellSelected, activeCell, handleMouseDown, handleMouseOver, handleCell
             return true
           case 'ArrowLeft':
             e.preventDefault()
+            clearSelectedRange()
             $e('c:shortcut', { key: 'CTRL + ArrowLeft' })
             activeCell.row = activeCell.row ?? 0
             activeCell.col = 0
@@ -282,7 +287,7 @@ const { isCellSelected, activeCell, handleMouseDown, handleMouseOver, handleCell
     },
     async (ctx: { row: number; col?: number; updatedColumnTitle?: string }) => {
       const rowObj = data.value[ctx.row]
-      const columnObj = ctx.col != null ? fields.value[ctx.col] : null
+      const columnObj = ctx.col !== undefined ? fields.value[ctx.col] : null
 
       if (!ctx.updatedColumnTitle && isVirtualCol(columnObj)) {
         return
@@ -297,7 +302,7 @@ function scrollToCell(row?: number | null, col?: number | null) {
   row = row ?? activeCell.row
   col = col ?? activeCell.col
 
-  if (row != null && col != null) {
+  if (row !== null && col !== null) {
     // get active cell
     const rows = tbodyEl.value?.querySelectorAll('tr')
     const cols = rows?.[row].querySelectorAll('td')
@@ -462,7 +467,7 @@ const smartTable = ref(null)
 onClickOutside(smartTable, (e) => {
   if (contextMenu.value) return
 
-  if (activeCell.row == null || activeCell.col == null) return
+  if (activeCell.row === null || activeCell.col === null) return
 
   const activeCol = fields.value[activeCell.col]
 
@@ -491,7 +496,7 @@ onClickOutside(smartTable, (e) => {
 })
 
 const onNavigate = (dir: NavigateDir) => {
-  if (activeCell.row == null || activeCell.col == null) return
+  if (activeCell.row === null || activeCell.col === null) return
 
   editEnabled = false
   clearSelectedRange()

--- a/packages/nc-gui/composables/useMultiSelect/cellRange.ts
+++ b/packages/nc-gui/composables/useMultiSelect/cellRange.ts
@@ -4,51 +4,53 @@ export interface Cell {
 }
 
 export class CellRange {
-  _start: Cell | null
-  _end: Cell | null
+  _start: Cell
+  _end: Cell
 
   constructor(start = null, end = null) {
-    this._start = start
+    this._start = start ?? { row: null, col: null }
     this._end = end ?? this._start
   }
 
-  get start() {
+  isEmpty() {
+    return this._start.col == null || this._start.row == null || this._end.col == null || this._end.row == null
+  }
+
+  isSingleCell() {
+    return !this.isEmpty() && this._start?.col === this._end?.col && this._start?.row === this._end?.row
+  }
+
+  get start(): Cell {
+    if (this.isEmpty()) {
+      return { row: null, col: null }
+    }
     return {
-      row: Math.min(this._start?.row ?? NaN, this._end?.row ?? NaN),
-      col: Math.min(this._start?.col ?? NaN, this._end?.col ?? NaN),
+      row: Math.min(this._start.row!, this._end.row!),
+      col: Math.min(this._start.col!, this._end.col!),
     }
   }
 
-  get end() {
+  get end(): Cell {
+    if (this.isEmpty()) {
+      return { row: null, col: null }
+    }
     return {
-      row: Math.max(this._start?.row ?? NaN, this._end?.row ?? NaN),
-      col: Math.max(this._start?.col ?? NaN, this._end?.col ?? NaN),
+      row: Math.max(this._start.row!, this._end.row!),
+      col: Math.max(this._start.col!, this._end.col!),
     }
   }
 
   startRange(value: Cell) {
-    if (value == null) {
-      return
-    }
-
     this._start = value
     this._end = value
   }
 
   endRange(value: Cell) {
-    if (value == null) {
-      return
-    }
-
     this._end = value
   }
 
   clear() {
-    this._start = null
-    this._end = null
-  }
-
-  isEmpty() {
-    return this._start == null || this._end == null
+    this._start = { row: null, col: null }
+    this._end = { row: null, col: null }
   }
 }

--- a/packages/nc-gui/composables/useMultiSelect/cellRange.ts
+++ b/packages/nc-gui/composables/useMultiSelect/cellRange.ts
@@ -1,19 +1,19 @@
 export interface Cell {
-  row: number | null
-  col: number | null
+  row: number
+  col: number
 }
 
 export class CellRange {
-  _start: Cell
-  _end: Cell
+  _start: Cell | null
+  _end: Cell | null
 
   constructor(start = null, end = null) {
-    this._start = start ?? { row: null, col: null }
+    this._start = start
     this._end = end ?? this._start
   }
 
   isEmpty() {
-    return this._start.col == null || this._start.row == null || this._end.col == null || this._end.row == null
+    return this._start == null || this._end == null
   }
 
   isSingleCell() {
@@ -21,22 +21,16 @@ export class CellRange {
   }
 
   get start(): Cell {
-    if (this.isEmpty()) {
-      return { row: null, col: null }
-    }
     return {
-      row: Math.min(this._start.row!, this._end.row!),
-      col: Math.min(this._start.col!, this._end.col!),
+      row: Math.min(this._start?.row ?? NaN, this._end?.row ?? NaN),
+      col: Math.min(this._start?.col ?? NaN, this._end?.col ?? NaN),
     }
   }
 
   get end(): Cell {
-    if (this.isEmpty()) {
-      return { row: null, col: null }
-    }
     return {
-      row: Math.max(this._start.row!, this._end.row!),
-      col: Math.max(this._start.col!, this._end.col!),
+      row: Math.max(this._start?.row ?? NaN, this._end?.row ?? NaN),
+      col: Math.max(this._start?.col ?? NaN, this._end?.col ?? NaN),
     }
   }
 
@@ -50,7 +44,7 @@ export class CellRange {
   }
 
   clear() {
-    this._start = { row: null, col: null }
-    this._end = { row: null, col: null }
+    this._start = null
+    this._end = null
   }
 }

--- a/packages/nc-gui/composables/useMultiSelect/index.ts
+++ b/packages/nc-gui/composables/useMultiSelect/index.ts
@@ -22,11 +22,13 @@ import {
   useProject,
 } from '#imports'
 
+const MAIN_MOUSE_PRESSED = 0
+
 /**
  * Utility to help with multi-selecting rows/cells in the smartsheet
  */
 export function useMultiSelect(
-  _meta: MaybeRef<TableType>,
+  _meta: MaybeRef<TableType | undefined>,
   fields: MaybeRef<ColumnType[]>,
   data: MaybeRef<Row[]>,
   _editEnabled: MaybeRef<boolean>,
@@ -51,25 +53,36 @@ export function useMultiSelect(
 
   const editEnabled = ref(_editEnabled)
 
-  const selectedCell = reactive<Cell>({ row: null, col: null })
-  const selectedRange = reactive(new CellRange())
   let isMouseDown = $ref(false)
+
+  const selectedRange = reactive(new CellRange())
+
+  const activeCell = reactive<Cell>({ row: null, col: null })
 
   const columnLength = $computed(() => unref(fields)?.length)
 
+  function makeActive(row: number | null, col: number | null) {
+    if (activeCell.row === row && activeCell.col === col) {
+      return
+    }
+
+    activeCell.row = row
+    activeCell.col = col
+  }
+
   async function copyValue(ctx?: Cell) {
     try {
-      if (!selectedRange.isEmpty()) {
-        const cprows = unref(data).slice(selectedRange.start.row, selectedRange.end.row + 1) // slice the selected rows for copy
-        const cpcols = unref(fields).slice(selectedRange.start.col, selectedRange.end.col + 1) // slice the selected cols for copy
+      if (!selectedRange.isEmpty() && !selectedRange.isSingleCell()) {
+        const cprows = unref(data).slice(selectedRange.start.row!, selectedRange.end.row! + 1) // slice the selected rows for copy
+        const cpcols = unref(fields).slice(selectedRange.start.col!, selectedRange.end.col! + 1) // slice the selected cols for copy
 
         await copyTable(cprows, cpcols)
         message.success(t('msg.info.copiedToClipboard'))
       } else {
         // if copy was called with context (right click position) - copy value from context
         // else if there is just one selected cell, copy it's value
-        const cpRow = ctx?.row ?? selectedCell?.row
-        const cpCol = ctx?.col ?? selectedCell?.col
+        const cpRow = ctx?.row ?? activeCell.row
+        const cpCol = ctx?.col ?? activeCell.col
 
         if (cpRow != null && cpCol != null) {
           const rowObj = unref(data)[cpRow]
@@ -93,25 +106,15 @@ export function useMultiSelect(
     }
   }
 
-  function selectCell(row: number, col: number) {
-    selectedRange.clear()
-    if (selectedCell.row === row && selectedCell.col === col) return
-    editEnabled.value = false
-    selectedCell.row = row
-    selectedCell.col = col
-  }
-
-  function endSelectRange(row: number, col: number) {
+  function handleMouseOver(row: number, col: number) {
     if (!isMouseDown) {
       return
     }
-    selectedCell.row = null
-    selectedCell.col = null
     selectedRange.endRange({ row, col })
   }
 
   function isCellSelected(row: number, col: number) {
-    if (selectedCell?.row === row && selectedCell?.col === col) {
+    if (activeCell.col === col && activeCell.row === row) {
       return true
     }
 
@@ -120,52 +123,60 @@ export function useMultiSelect(
     }
 
     return (
-      col >= selectedRange.start.col &&
-      col <= selectedRange.end.col &&
-      row >= selectedRange.start.row &&
-      row <= selectedRange.end.row
+      col >= selectedRange.start.col! &&
+      col <= selectedRange.end.col! &&
+      row >= selectedRange.start.row! &&
+      row <= selectedRange.end.row!
     )
   }
 
-  function startSelectRange(event: MouseEvent, row: number, col: number) {
+  function handleMouseDown(event: MouseEvent, row: number, col: number) {
     // if there was a right click on selected range, don't restart the selection
-    const leftClickButton = 0
-    if (event?.button !== leftClickButton && isCellSelected(row, col)) {
+    if (event?.button !== MAIN_MOUSE_PRESSED && isCellSelected(row, col)) {
       return
     }
 
-    if (unref(editEnabled)) {
-      event.preventDefault()
-      return
-    }
-
+    editEnabled.value = false
     isMouseDown = true
-    selectedRange.clear()
     selectedRange.startRange({ row, col })
   }
 
-  useEventListener(document, 'mouseup', (e) => {
-    // if the editEnabled is false prevent the mouseup event for not select text
+  const handleCellClick = (event: MouseEvent, row: number, col: number) => {
+    isMouseDown = true
+    editEnabled.value = false
+    selectedRange.startRange({ row, col })
+    selectedRange.endRange({ row, col })
+    makeActive(row, col)
+    isMouseDown = false
+  }
+
+  const handleMouseUp = (event: MouseEvent) => {
+    // timeout is needed, because we want to set cell as active AFTER all the child's click handler's called
+    // this is needed e.g. for date field edit, where two clicks had to be done - one to select cell, and another one to open date dropdown
+    setTimeout(() => {
+      makeActive(selectedRange.start.row, selectedRange.start.col)
+    }, 0)
+
+    // if the editEnabled is false, prevent selecting text on mouseUp
     if (!unref(editEnabled)) {
-      e.preventDefault()
+      event.preventDefault()
     }
 
     isMouseDown = false
-  })
+  }
 
-  const onKeyDown = async (e: KeyboardEvent) => {
+  const handleKeyDown = async (e: KeyboardEvent) => {
     // invoke the keyEventHandler if provided and return if it returns true
     if (await keyEventHandler?.(e)) {
+      console.log('in first if')
+      selectedRange.clear()
+
       return true
     }
 
-    if (!selectedRange.isEmpty()) {
-      // In case the user press tabs or arrows keys
-      selectedCell.row = selectedRange.start.row
-      selectedCell.col = selectedRange.start.col
+    if (activeCell.row == null || activeCell.col == null) {
+      return
     }
-
-    if (selectedCell.row === null || selectedCell.col === null) return
 
     /** on tab key press navigate through cells */
     switch (e.key) {
@@ -174,21 +185,21 @@ export function useMultiSelect(
         selectedRange.clear()
 
         if (e.shiftKey) {
-          if (selectedCell.col > 0) {
-            selectedCell.col--
+          if (activeCell.col > 0) {
+            activeCell.col--
             editEnabled.value = false
-          } else if (selectedCell.row > 0) {
-            selectedCell.row--
-            selectedCell.col = unref(columnLength) - 1
+          } else if (activeCell.row > 0) {
+            activeCell.row--
+            activeCell.col = unref(columnLength) - 1
             editEnabled.value = false
           }
         } else {
-          if (selectedCell.col < unref(columnLength) - 1) {
-            selectedCell.col++
+          if (activeCell.col < unref(columnLength) - 1) {
+            activeCell.col++
             editEnabled.value = false
-          } else if (selectedCell.row < unref(data).length - 1) {
-            selectedCell.row++
-            selectedCell.col = 0
+          } else if (activeCell.row < unref(data).length - 1) {
+            activeCell.row++
+            activeCell.col = 0
             editEnabled.value = false
           }
         }
@@ -196,65 +207,70 @@ export function useMultiSelect(
         break
       /** on enter key press make cell editable */
       case 'Enter':
-        e.preventDefault()
         selectedRange.clear()
-        makeEditable(unref(data)[selectedCell.row], unref(fields)[selectedCell.col])
+
+        e.preventDefault()
+        makeEditable(unref(data)[activeCell.row], unref(fields)[activeCell.col])
         break
       /** on delete key press clear cell */
       case 'Delete':
-        e.preventDefault()
         selectedRange.clear()
-        await clearCell(selectedCell as { row: number; col: number })
+
+        e.preventDefault()
+        await clearCell(activeCell as { row: number; col: number })
         break
       /** on arrow key press navigate through cells */
       case 'ArrowRight':
-        e.preventDefault()
         selectedRange.clear()
-        if (selectedCell.col < unref(columnLength) - 1) {
-          selectedCell.col++
+
+        e.preventDefault()
+        if (activeCell.col < unref(columnLength) - 1) {
+          activeCell.col++
           scrollToActiveCell?.()
           editEnabled.value = false
         }
         break
       case 'ArrowLeft':
         selectedRange.clear()
+
         e.preventDefault()
-        if (selectedCell.col > 0) {
-          selectedCell.col--
+        if (activeCell.col > 0) {
+          activeCell.col--
           scrollToActiveCell?.()
           editEnabled.value = false
         }
         break
       case 'ArrowUp':
         selectedRange.clear()
+
         e.preventDefault()
-        if (selectedCell.row > 0) {
-          selectedCell.row--
+        if (activeCell.row > 0) {
+          activeCell.row--
           scrollToActiveCell?.()
           editEnabled.value = false
         }
         break
       case 'ArrowDown':
         selectedRange.clear()
+
         e.preventDefault()
-        if (selectedCell.row < unref(data).length - 1) {
-          selectedCell.row++
+        if (activeCell.row < unref(data).length - 1) {
+          activeCell.row++
           scrollToActiveCell?.()
           editEnabled.value = false
         }
         break
       default:
         {
-          const rowObj = unref(data)[selectedCell.row]
-
-          const columnObj = unref(fields)[selectedCell.col]
+          const rowObj = unref(data)[activeCell.row]
+          const columnObj = unref(fields)[activeCell.col]
 
           if ((!unref(editEnabled) || !isTypableInputColumn(columnObj)) && (isMac() ? e.metaKey : e.ctrlKey)) {
             switch (e.keyCode) {
               // copy - ctrl/cmd +c
               case 67:
                 // set clipboard context only if single cell selected
-                if (rowObj.row[columnObj.title!]) {
+                if (selectedRange.isSingleCell() && rowObj.row[columnObj.title!]) {
                   clipboardContext = {
                     value: rowObj.row[columnObj.title!],
                     uidt: columnObj.uidt as UITypes,
@@ -264,6 +280,7 @@ export function useMultiSelect(
                 }
                 await copyValue()
                 break
+              // paste - ctrl/cmd + v
               case 86:
                 try {
                   // handle belongs to column
@@ -297,7 +314,7 @@ export function useMultiSelect(
                       (relatedTableMeta as any)!.columns!,
                     )
 
-                    return await syncCellData?.({ ...selectedCell, updatedColumnTitle: foreignKeyColumn.title })
+                    return await syncCellData?.({ ...activeCell, updatedColumnTitle: foreignKeyColumn.title })
                   }
 
                   // if it's a virtual column excluding belongs to cell type skip paste
@@ -315,9 +332,9 @@ export function useMultiSelect(
                       isMysql.value,
                     )
                     e.preventDefault()
-                    syncCellData?.(selectedCell)
+                    syncCellData?.(activeCell)
                   } else {
-                    clearCell(selectedCell as { row: number; col: number }, true)
+                    clearCell(activeCell as { row: number; col: number }, true)
                     makeEditable(rowObj, columnObj)
                   }
                 } catch (error: any) {
@@ -346,15 +363,18 @@ export function useMultiSelect(
     }
   }
 
-  useEventListener(document, 'keydown', onKeyDown)
+  const clearSelectedRange = selectedRange.clear.bind(selectedRange)
+
+  useEventListener(document, 'keydown', handleKeyDown)
+  useEventListener(document, 'mouseup', handleMouseUp)
 
   return {
-    selectCell,
-    startSelectRange,
-    endSelectRange,
-    clearSelectedRange: selectedRange.clear.bind(selectedRange),
+    handleMouseDown,
+    handleMouseOver,
+    clearSelectedRange,
     copyValue,
     isCellSelected,
-    selectedCell,
+    activeCell,
+    handleCellClick,
   }
 }

--- a/packages/nc-gui/lib/types.ts
+++ b/packages/nc-gui/lib/types.ts
@@ -100,3 +100,5 @@ export interface SharedView {
 export type importFileList = (UploadFile & { data: string | ArrayBuffer })[]
 
 export type streamImportFileList = UploadFile[]
+
+export type Nullable<T> = { [K in keyof T]: T[K] | null }

--- a/tests/playwright/pages/Dashboard/Grid/index.ts
+++ b/tests/playwright/pages/Dashboard/Grid/index.ts
@@ -1,7 +1,7 @@
 import { expect, Locator } from '@playwright/test';
 import { DashboardPage } from '..';
 import BasePage from '../../Base';
-import { CellPageObject } from '../common/Cell';
+import { CellPageObject, CellProps } from '../common/Cell';
 import { ColumnPageObject } from './Column';
 import { ToolbarPage } from '../common/Toolbar';
 import { ProjectMenuObject } from '../common/ProjectMenu';
@@ -285,5 +285,35 @@ export class GridPage extends BasePage {
     await expect(this.get().locator('.nc-grid-add-new-cell')).toHaveCount(
       param.role === 'creator' || param.role === 'editor' ? 1 : 0
     );
+  }
+
+  async selectRange({ start, end }: { start: CellProps; end: CellProps }) {
+    const startCell = await this.cell.get({ index: start.index, columnHeader: start.columnHeader });
+    const endCell = await this.cell.get({ index: end.index, columnHeader: end.columnHeader });
+    const page = await this.dashboard.get().page();
+    await startCell.hover();
+    await page.mouse.down();
+    await endCell.hover();
+    await page.mouse.up();
+  }
+
+  async selectedCount() {
+    return this.get().locator('.cell.active').count();
+  }
+
+  async copyWithKeyboard() {
+    await this.get().press((await this.isMacOs()) ? 'Meta+C' : 'Control+C');
+    await this.verifyToast({ message: 'Copied to clipboard' });
+
+    return this.getClipboardText();
+  }
+
+  async copyWithMouse({ index, columnHeader }: CellProps) {
+    await this.cell.get({ index, columnHeader }).click({ button: 'right' });
+    await this.get().page().getByTestId('context-menu-item-copy').click();
+
+    await this.verifyToast({ message: 'Copied to clipboard' });
+
+    return this.getClipboardText();
   }
 }

--- a/tests/playwright/pages/Dashboard/common/Cell/index.ts
+++ b/tests/playwright/pages/Dashboard/common/Cell/index.ts
@@ -8,6 +8,11 @@ import { CheckboxCellPageObject } from './CheckboxCell';
 import { RatingCellPageObject } from './RatingCell';
 import { DateCellPageObject } from './DateCell';
 
+export interface CellProps {
+  index?: number;
+  columnHeader: string;
+}
+
 export class CellPageObject extends BasePage {
   readonly parent: GridPage | SharedFormPage;
   readonly selectOption: SelectOptionCellPageObject;
@@ -26,7 +31,7 @@ export class CellPageObject extends BasePage {
     this.date = new DateCellPageObject(this);
   }
 
-  get({ index, columnHeader }: { index?: number; columnHeader: string }): Locator {
+  get({ index, columnHeader }: CellProps): Locator {
     if (this.parent instanceof SharedFormPage) {
       return this.parent.get().locator(`[data-testid="nc-form-input-cell-${columnHeader}"]`);
     } else {
@@ -34,19 +39,16 @@ export class CellPageObject extends BasePage {
     }
   }
 
-  async click(
-    { index, columnHeader }: { index: number; columnHeader: string },
-    ...options: Parameters<Locator['click']>
-  ) {
+  async click({ index, columnHeader }: CellProps, ...options: Parameters<Locator['click']>) {
     await this.get({ index, columnHeader }).click(...options);
     await (await this.get({ index, columnHeader }).elementHandle()).waitForElementState('stable');
   }
 
-  async dblclick({ index, columnHeader }: { index?: number; columnHeader: string }) {
+  async dblclick({ index, columnHeader }: CellProps) {
     return await this.get({ index, columnHeader }).dblclick();
   }
 
-  async fillText({ index, columnHeader, text }: { index?: number; columnHeader: string; text: string }) {
+  async fillText({ index, columnHeader, text }: CellProps & { text: string }) {
     await this.dblclick({
       index,
       columnHeader,
@@ -54,7 +56,7 @@ export class CellPageObject extends BasePage {
     await this.get({ index, columnHeader }).locator('input').fill(text);
   }
 
-  async inCellExpand({ index, columnHeader }: { index: number; columnHeader: string }) {
+  async inCellExpand({ index, columnHeader }: CellProps) {
     await this.get({ index, columnHeader }).hover();
     await this.waitForResponse({
       uiAction: this.get({ index, columnHeader }).locator('.nc-action-icon >> nth=0').click(),
@@ -63,20 +65,20 @@ export class CellPageObject extends BasePage {
     });
   }
 
-  async inCellAdd({ index, columnHeader }: { index: number; columnHeader: string }) {
+  async inCellAdd({ index, columnHeader }: CellProps) {
     await this.get({ index, columnHeader }).hover();
     await this.get({ index, columnHeader }).locator('.nc-action-icon.nc-plus').click();
   }
 
-  async verifyCellActiveSelected({ index, columnHeader }: { index: number; columnHeader: string }) {
+  async verifyCellActiveSelected({ index, columnHeader }: CellProps) {
     await expect(this.get({ index, columnHeader })).toHaveClass(/active/);
   }
 
-  async verifyCellEditable({ index, columnHeader }: { index: number; columnHeader: string }) {
+  async verifyCellEditable({ index, columnHeader }: CellProps) {
     await this.get({ index, columnHeader }).isEditable();
   }
 
-  async verify({ index, columnHeader, value }: { index: number; columnHeader: string; value: string | string[] }) {
+  async verify({ index, columnHeader, value }: CellProps & { value: string | string[] }) {
     const _verify = async text => {
       await expect
         .poll(async () => {
@@ -102,9 +104,7 @@ export class CellPageObject extends BasePage {
     index,
     columnHeader,
     expectedSrcValue,
-  }: {
-    index: number;
-    columnHeader: string;
+  }: CellProps & {
     expectedSrcValue: string;
   }) {
     const _verify = async expectedQrCodeImgSrc => {
@@ -134,9 +134,7 @@ export class CellPageObject extends BasePage {
     columnHeader,
     count,
     value,
-  }: {
-    index: number;
-    columnHeader: string;
+  }: CellProps & {
     count?: number;
     value: string[];
   }) {
@@ -153,7 +151,7 @@ export class CellPageObject extends BasePage {
     }
   }
 
-  async unlinkVirtualCell({ index, columnHeader }: { index: number; columnHeader: string }) {
+  async unlinkVirtualCell({ index, columnHeader }: CellProps) {
     const cell = this.get({ index, columnHeader });
     await cell.click();
     await cell.locator('.nc-icon.unlink-icon').click();
@@ -187,12 +185,18 @@ export class CellPageObject extends BasePage {
     );
   }
 
-  async copyToClipboard(
-    { index, columnHeader }: { index: number; columnHeader: string },
-    ...clickOptions: Parameters<Locator['click']>
-  ) {
+  async copyToClipboard({ index, columnHeader }: CellProps, ...clickOptions: Parameters<Locator['click']>) {
     await this.get({ index, columnHeader }).click(...clickOptions);
 
     await this.get({ index, columnHeader }).press((await this.isMacOs()) ? 'Meta+C' : 'Control+C');
+  }
+
+  async selectRange({ start, end }: { start: CellProps; end: CellProps }) {
+    const startCell = await this.get({ index: start.index, columnHeader: start.columnHeader });
+    const endCell = await this.get({ index: end.index, columnHeader: end.columnHeader });
+    const page = await startCell.page();
+    await page.mouse.down();
+    await endCell.hover();
+    await page.mouse.up();
   }
 }

--- a/tests/playwright/tests/cellSelection.spec.ts
+++ b/tests/playwright/tests/cellSelection.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from '@playwright/test';
+import { DashboardPage } from '../pages/Dashboard';
+import { GridPage } from '../pages/Dashboard/Grid';
+import setup from '../setup';
+
+test.describe('Verify cell selection', () => {
+  let dashboard: DashboardPage, grid: GridPage;
+  let context: any;
+
+  test.beforeEach(async ({ page }) => {
+    context = await setup({ page });
+    dashboard = new DashboardPage(page, context.project);
+    grid = dashboard.grid;
+  });
+
+  test('#1 when range is selected, it has correct number of selected cells', async () => {
+    await dashboard.treeView.openTable({ title: 'Country' });
+    await grid.selectRange({
+      start: { index: 0, columnHeader: 'Country' },
+      end: { index: 2, columnHeader: 'City List' },
+    });
+
+    expect(await grid.selectedCount()).toBe(9);
+  });
+
+  test('#2 when copied with clipboard, it copies correct text', async () => {
+    await dashboard.treeView.openTable({ title: 'Country' });
+    await grid.selectRange({
+      start: { index: 0, columnHeader: 'Country' },
+      end: { index: 1, columnHeader: 'LastUpdate' },
+    });
+
+    expect(await grid.copyWithKeyboard()).toBe(
+      'Afghanistan \t 2006-02-15 04:44:00\n' + ' Algeria \t 2006-02-15 04:44:00\n'
+    );
+  });
+
+  test('#3 when copied with mouse, it copies correct text', async () => {
+    await dashboard.treeView.openTable({ title: 'Country' });
+    await grid.selectRange({
+      start: { index: 0, columnHeader: 'Country' },
+      end: { index: 1, columnHeader: 'LastUpdate' },
+    });
+
+    expect(await grid.copyWithMouse({ index: 0, columnHeader: 'Country' })).toBe(
+      'Afghanistan \t 2006-02-15 04:44:00\n' + ' Algeria \t 2006-02-15 04:44:00\n'
+    );
+  });
+
+  // FIXME: this is edge case, better be moved to integration tests
+  test('#4 when cell inside selection range is clicked, it clears previous selection', async () => {
+    await dashboard.treeView.openTable({ title: 'Country' });
+    await grid.selectRange({
+      start: { index: 0, columnHeader: 'Country' },
+      end: { index: 2, columnHeader: 'City List' },
+    });
+
+    expect(await grid.selectedCount()).toBe(9);
+
+    await grid.cell.get({ index: 0, columnHeader: 'Country' }).click();
+
+    expect(await grid.selectedCount()).toBe(1);
+    expect(await grid.cell.verifyCellActiveSelected({ index: 0, columnHeader: 'Country' }));
+  });
+
+  // FIXME: this is edge case, better be moved to integration tests
+  test('#5 when cell outside selection range is clicked, it clears previous selection', async () => {
+    await dashboard.treeView.openTable({ title: 'Country' });
+    await grid.selectRange({
+      start: { index: 0, columnHeader: 'Country' },
+      end: { index: 2, columnHeader: 'City List' },
+    });
+
+    expect(await grid.selectedCount()).toBe(9);
+
+    await grid.cell.get({ index: 5, columnHeader: 'Country' }).click();
+
+    expect(await grid.selectedCount()).toBe(1);
+    expect(await grid.cell.verifyCellActiveSelected({ index: 5, columnHeader: 'Country' }));
+  });
+
+  // FIXME: this is edge case, better be moved to integration tests
+  test('#6 when selection ends on locked field, it still works as expected', async () => {
+    await dashboard.treeView.openTable({ title: 'Country' });
+    await dashboard.grid.toolbar.fields.toggleShowSystemFields();
+    await grid.selectRange({
+      start: { index: 2, columnHeader: 'City List' },
+      end: { index: 0, columnHeader: 'CountryId' },
+    });
+
+    expect(await grid.selectedCount()).toBe(12);
+
+    await grid.cell.get({ index: 1, columnHeader: 'Country' }).click();
+
+    expect(await grid.selectedCount()).toBe(1);
+    expect(await grid.cell.verifyCellActiveSelected({ index: 1, columnHeader: 'Country' }));
+  });
+
+  // FIXME: this is edge case, better be moved to integration tests
+  test('#7 when navigated with keyboard, only active cell is affected', async ({ page }) => {
+    await dashboard.treeView.openTable({ title: 'Country' });
+    await grid.selectRange({
+      start: { index: 0, columnHeader: 'Country' },
+      end: { index: 2, columnHeader: 'City List' },
+    });
+
+    await page.keyboard.press('ArrowRight');
+    expect(await grid.selectedCount()).toBe(1);
+    expect(await grid.cell.verifyCellActiveSelected({ index: 0, columnHeader: 'LastUpdate' }));
+  });
+});


### PR DESCRIPTION
## Change Summary

Locked cells break multiselect behavior since they stop click event.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

"By sense" it would be much better, if activeCell was computed upon selectedRange, but since selectedRange should be updated straightaway, and cell should become active only after child clicks are handled (to maintain old behavior, e.g. to edit date field, two clicks had to be done -- one to select cell, and another one to open date dropdown). The same could be achieved with async computed, but I didn't want to install additional library.

A little more "oddness" adds the fact, that
a) we want cell become active BEFORE dblclick handler
b) for MultiSelect data cell mouseDown event is prevented inside the component, so it's necessary to handle range both on click and on mouse down

Bug video:

https://user-images.githubusercontent.com/31967149/207728904-b5b1475b-26d1-4583-9aa0-661e05b5d47d.mov

