### PR TITLE
TOOL-22: fix broken preview for private attachments

### DIFF
--- a/packages/nocodb/src/lib/meta/api/attachmentApis.ts
+++ b/packages/nocodb/src/lib/meta/api/attachmentApis.ts
@@ -158,7 +158,7 @@ async function uploadAttachment(filePath, column, files, ncSiteUrl) {
         mimetype: file.mimetype,
         size: file.size,
         icon: mimeIcons[path.extname(file.originalname).slice(1)] || undefined,
-        ...(!column.public ? s3KeyObject(storageAdapter, relativePath) : {})
+        ...(!column.public ? s3KeyObject(storageAdapter, relativePath) : {}),
       };
     })
   );
@@ -185,7 +185,8 @@ function s3KeyObject(storageAdapter, key: string) {
   if (!(storageAdapter instanceof S3)) return {};
 
   return {
-    S3Key: key
+    S3Key: key,
+    url: storageAdapter.getSignedUrl(key),
   };
 }
 


### PR DESCRIPTION
## Change Summary

The url returned after private attachment upload should be also enriched with aws signature

## Change type

- [] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
