### PR TITLE
TOOL-56: popup on option removal

### DIFF
--- a/packages/nc-gui/components.d.ts
+++ b/packages/nc-gui/components.d.ts
@@ -48,6 +48,7 @@ declare module '@vue/runtime-core' {
     AntDesignMenuFoldOutlined: typeof import('~icons/ant-design/menu-fold-outlined')['default']
     AntDesignMenuUnfoldOutlined: typeof import('~icons/ant-design/menu-unfold-outlined')['default']
     APagination: typeof import('ant-design-vue/es')['Pagination']
+    APopconfirm: typeof import('ant-design-vue/es')['Popconfirm']
     ARadio: typeof import('ant-design-vue/es')['Radio']
     ARadioGroup: typeof import('ant-design-vue/es')['RadioGroup']
     ARate: typeof import('ant-design-vue/es')['Rate']

--- a/packages/nc-gui/components/smartsheet/column/SelectOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/SelectOptions.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import Draggable from 'vuedraggable'
 import { UITypes } from 'nocodb-sdk'
-import { IsKanbanInj, enumColor, onMounted, useColumnCreateStoreOrThrow, useVModel, watch } from '#imports'
+import { IsKanbanInj, enumColor, onMounted, useColumnCreateStoreOrThrow, useI18n, useVModel, watch } from '#imports'
 
 const props = defineProps<{
   value: any
@@ -48,6 +48,8 @@ const validators = {
     },
   ],
 }
+
+const { t } = useI18n()
 
 setAdditionalValidations({
   ...validators,
@@ -167,11 +169,22 @@ watch(inputs, () => {
               @change="optionChanged(element.id)"
             />
 
-            <MdiClose
-              class="ml-2 hover:!text-black-500 text-gray-500 cursor-pointer"
-              :data-testid="`select-column-option-remove-${index}`"
-              @click="removeOption(index)"
-            />
+            <a-popconfirm :cancel-text="`${t('general.no')}`" @confirm="removeOption(index)">
+              <template #title>
+                <span class="whitespace-pre-wrap">
+                  {{ t('msg.info.confirmOptionRemoval') }}
+                </span>
+              </template>
+
+              <template #okText>
+                <span data-testid="confirm-option-removal"> {{ t('general.yes') }}</span>
+              </template>
+
+              <MdiClose
+                class="ml-2 hover:!text-black-500 text-gray-500 cursor-pointer"
+                :data-testid="`select-column-option-remove-${index}`"
+              />
+            </a-popconfirm>
           </div>
         </template>
       </Draggable>

--- a/packages/nc-gui/lang/en.json
+++ b/packages/nc-gui/lang/en.json
@@ -504,6 +504,7 @@
       }
     },
     "info": {
+      "confirmOptionRemoval": "Do you want to delete this option?\nOnce you click the save button, you cannot undo the operation",
       "pasteNotSupported": "Paste operation is not supported on the active cell",
       "roles": {
         "orgCreator": "Creator can create new projects and access any invited project.",

--- a/tests/playwright/pages/Dashboard/Grid/Column/SelectOptionColumn.ts
+++ b/tests/playwright/pages/Dashboard/Grid/Column/SelectOptionColumn.ts
@@ -49,6 +49,8 @@ export class SelectOptionColumnPageObject extends BasePage {
 
     await this.column.get().locator(`svg[data-testid="select-column-option-remove-${index}"]`).click();
 
+    await this.column.rootPage.getByTestId('confirm-option-removal').click();
+
     await this.column.save({ isUpdated: true });
   }
 


### PR DESCRIPTION
## Change Summary

Add popup on option removal

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
