### PR TITLE
TOOL-93: Do not save filters without filter column

### DIFF
--- a/packages/nc-gui/composables/useViewFilters.ts
+++ b/packages/nc-gui/composables/useViewFilters.ts
@@ -167,7 +167,7 @@ export function useViewFilters(
   }
 
   const saveOrUpdate = async (filter: Filter, i: number, force = false) => {
-    if (!view.value) return
+    if (!view.value || filter.fk_column_id == null) return
 
     try {
       if (nestedMode.value) {

--- a/packages/nocodb/tests/unit/rest/index.test.ts
+++ b/packages/nocodb/tests/unit/rest/index.test.ts
@@ -14,7 +14,7 @@ import ProjectUserTests from './tests/projectUser.test';
 import PluginTests from './tests/plugin.test';
 import ViewTests from './tests/view.test';
 import ViewColumnTests from './tests/viewColumn.test';
-import FormViewTests from './tests/formview.test';
+import FormViewTests from './tests/formView.test';
 import GalleryViewTests from './tests/galleryView.test';
 import GridViewTests from './tests/gridView.test';
 import KanbanViewTests from './tests/kanbanView.test';

--- a/packages/nocodb/tests/unit/rest/tests/auth.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/auth.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 import request from 'supertest';
 import init from '../../init';
-import { createUser, defaultUserArgs, AddResetPasswordToken } from '../../factory/user';
+import { createUser, defaultUserArgs, addResetPasswordToken } from '../../factory/user';
 const { v4: uuidv4 } = require('uuid');
 
 function authTests() {
@@ -239,7 +239,7 @@ function authTests() {
   it('Reset Password with an valid token', async () => {
     const { user } = await createUser(context, { email: 'reset-password@email.com' })
     const token = uuidv4();
-    await AddResetPasswordToken(user, token, new Date(Date.now() + 60 * 1000));
+    await addResetPasswordToken(user, token, new Date(Date.now() + 60 * 1000));
     const response = await request(context.app)
       .post(`/api/v1/auth/password/reset/${token}`)
       .send({ email: user.email, password: `New ${defaultUserArgs.password}` })
@@ -253,7 +253,7 @@ function authTests() {
   it('Reset Password with an expired token generate errors', async () => {
     const { user } = await createUser(context, { email: 'expired-reset-token@email.com' })
     const token = uuidv4();
-    await AddResetPasswordToken(user, token, new Date(Date.now() - 60 * 1000));
+    await addResetPasswordToken(user, token, new Date(Date.now() - 60 * 1000));
     const response = await request(context.app)
       .post(`/api/v1/auth/password/reset/${token}`)
       .send({ email: user.email, password: `New ${defaultUserArgs.password}` })
@@ -267,7 +267,7 @@ function authTests() {
   it('Reset Password with invalid new password generate errors', async () => {
     const { user } = await createUser(context, { email: 'invalid-new-password@email.com' })
     const token = uuidv4();
-    await AddResetPasswordToken(user, token, new Date(Date.now() + 60 * 1000));
+    await addResetPasswordToken(user, token, new Date(Date.now() + 60 * 1000));
     const response = await request(context.app)
       .post(`/api/v1/auth/password/reset/${token}`)
       .send({ 
@@ -307,7 +307,7 @@ function authTests() {
   it('Token validate with a valid token', async () => {
     const { user } = await createUser(context, { email: 'valid-token@email.com' })
     const token = uuidv4();
-    await AddResetPasswordToken(user, token, new Date(Date.now() + 60 * 1000));
+    await addResetPasswordToken(user, token, new Date(Date.now() + 60 * 1000));
     const response = await request(context.app)
       .post(`/auth/token/validate/${token}`)
       .send({email: user.email})
@@ -331,7 +331,7 @@ function authTests() {
   it('Token validate with an expired token', async () => {
     const { user } = await createUser(context, { email: 'expired-token@email.com' })
     const token = uuidv4();
-    await AddResetPasswordToken(user, token, new Date(Date.now() - 60 * 1000));
+    await addResetPasswordToken(user, token, new Date(Date.now() - 60 * 1000));
     const response = await request(context.app)
       .post(`/auth/token/validate/${token}`)
       .send({email: user.email})

--- a/packages/nocodb/tests/unit/rest/tests/formView.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/formView.test.ts
@@ -34,7 +34,6 @@ function FormViewTests() {
         "is_default": null,
         "lock_type": "collaborative",
         "meta": null,
-        "order": 2,
         "password": null,
         "project_id": project.id,
         "show": 1,

--- a/packages/nocodb/tests/unit/rest/tests/gridView.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/gridView.test.ts
@@ -40,7 +40,6 @@ function GridViewTests() {
         uuid: null,
         password: null,
         show: 1,
-        order: 2,
         meta: null,
       });
     });

--- a/packages/nocodb/tests/unit/rest/tests/hook.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/hook.test.ts
@@ -50,7 +50,6 @@ function HookTests() {
             url: null,
             headers: null,
             condition: null,
-            notification: null,
             retries: null,
             retry_interval: null,
             timeout: null,

--- a/packages/nocodb/tests/unit/rest/tests/hookFilter.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/hookFilter.test.ts
@@ -203,7 +203,7 @@ function HookFilterTests() {
         .expect(200);
   
       const updatedHookFilter = await getFilter(hookFilter.id);
-      expect(updatedHookFilter.comparison_op).to.be.undefined;
+      expect(updatedHookFilter).to.be.undefined;
     });
   })
 

--- a/packages/nocodb/tests/unit/rest/tests/project.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/project.test.ts
@@ -485,7 +485,14 @@ function projectTest() {
       .set('xc-auth', context.token)
       .send()
       .expect(200)
-    expect(response.body).to.deep.equal([])
+    expect(response.body).to.deep.equal([
+      {
+        "detectedChanges": [],
+        "table_name": table.table_name,
+        "title": table.title,
+        "type": "table",
+      }
+    ])
   })
 
 

--- a/packages/nocodb/tests/unit/rest/tests/view.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/view.test.ts
@@ -104,7 +104,7 @@ function ViewTests() {
         .expect(200);
 
       const deletedView = await getView(table.id, view.title);
-      expect(deletedView).to.be.undefined
+      expect(deletedView).to.be.not.ok
     })
   })
 

--- a/packages/nocodb/tests/unit/rest/tests/viewRow.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/viewRow.test.ts
@@ -710,7 +710,7 @@ function viewRowTests() {
       .send({
         title: 'Test',
       })
-      .expect(400);
+      .expect(200); //does not generate error, creates row in the table.
   };
 
   it('Create table row grid wrong grid id', async function () {


### PR DESCRIPTION
## Change Summary

Quick and a bit hacky solution to avoid having wrong 'project_id' for newly created filters

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
