### PR TITLE
TOOL-131: sentry for frontend

### DIFF
--- a/packages/nc-gui/app.vue
+++ b/packages/nc-gui/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { applyNonSelectable, computed, useRoute, useTheme } from '#imports'
+import { applyNonSelectable, computed, message, useNuxtApp, useRoute, useTheme } from '#imports'
 
 const route = useRoute()
 
@@ -8,6 +8,15 @@ const disableBaseLayout = computed(() => route.path.startsWith('/nc/view') || ro
 useTheme()
 
 applyNonSelectable()
+
+const { $sentryCaptureException } = useNuxtApp()
+
+message.error = new Proxy(message.error, {
+  apply: (target, thisArg, argArray) => {
+    $sentryCaptureException(argArray)
+    return Reflect.apply(target, thisArg, argArray)
+  },
+})
 
 // TODO: Remove when https://github.com/vuejs/core/issues/5513 fixed
 const key = ref(0)

--- a/packages/nc-gui/composables/useGlobal/index.ts
+++ b/packages/nc-gui/composables/useGlobal/index.ts
@@ -37,7 +37,7 @@ export * from './types'
  * ```
  */
 export const useGlobal = createGlobalState((): UseGlobalReturn => {
-  const { provide } = useNuxtApp()
+  const { provide, $sentrySetUser } = useNuxtApp()
 
   const state = useGlobalState()
 
@@ -71,6 +71,9 @@ export const useGlobal = createGlobalState((): UseGlobalReturn => {
           firstname: nextPayload.firstname,
           lastname: nextPayload.lastname,
           roles: nextPayload.roles,
+        }
+        if ($sentrySetUser) {
+          $sentrySetUser({ id: nextPayload.id, email: nextPayload.email })
         }
       }
     },

--- a/packages/nc-gui/composables/useGlobal/state.ts
+++ b/packages/nc-gui/composables/useGlobal/state.ts
@@ -85,6 +85,8 @@ export function useGlobalState(storageKey = 'nocodb-gui-v2'): State {
   })
 
   const appInfo = ref<AppInfo>({
+    canCreateProjectWithoutExternalDB: false,
+    noSignUp: false,
     ncSiteUrl: BASE_FALLBACK_URL,
     authType: 'jwt',
     connectToExternalDB: false,
@@ -99,6 +101,8 @@ export function useGlobalState(storageKey = 'nocodb-gui-v2'): State {
     type: 'nocodb',
     version: '0.0.0',
     useFinnTheme: false,
+    sentryDsnFrontend: '',
+    platform: '',
   })
 
   /** reactive token payload */

--- a/packages/nc-gui/composables/useGlobal/types.ts
+++ b/packages/nc-gui/composables/useGlobal/types.ts
@@ -28,6 +28,8 @@ export interface AppInfo {
   type: string
   version: string
   useFinnTheme: boolean
+  sentryDsnFrontend: string
+  platform: string
 }
 
 export interface StoredState {

--- a/packages/nc-gui/nuxt-shim.d.ts
+++ b/packages/nc-gui/nuxt-shim.d.ts
@@ -1,4 +1,5 @@
 import type { Api as BaseAPI } from 'nocodb-sdk'
+import type * as Sentry from '@sentry/vue'
 import type { UseGlobalReturn } from './composables/useGlobal/types'
 import type { NocoI18n } from './lib'
 import type { TabType } from './composables'
@@ -13,6 +14,9 @@ declare module '#app/nuxt' {
     /** {@link import('./plugins/tele') Telemetry} Emit telemetry event */
     $e: (event: string, data?: any) => void
     $state: UseGlobalReturn
+    $sentryCaptureException: typeof Sentry.captureException
+    $sentrySetUser: typeof Sentry.setUser
+    $sentryAddBreadcrumb: typeof Sentry.addBreadcrumb
   }
 }
 

--- a/packages/nc-gui/nuxt.config.ts
+++ b/packages/nc-gui/nuxt.config.ts
@@ -13,6 +13,11 @@ export default defineNuxtConfig({
 
   ssr: false,
 
+  sourcemap: {
+    client: true,
+    server: false,
+  },
+
   app: {
     pageTransition: process.env.NUXT_PAGE_TRANSITION_DISABLE
       ? false

--- a/packages/nc-gui/package-lock.json
+++ b/packages/nc-gui/package-lock.json
@@ -9,6 +9,9 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.2.0",
+        "@sentry/browser": "^7.35.0",
+        "@sentry/tracing": "^7.35.0",
+        "@sentry/vue": "^7.35.0",
         "@vue-flow/additional-components": "^1.2.0",
         "@vue-flow/core": "^1.3.0",
         "@vuelidate/core": "^2.0.0-alpha.44",
@@ -2393,6 +2396,124 @@
       "engines": {
         "node": ">= 8.0.0"
       }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.36.0.tgz",
+      "integrity": "sha512-Mu0OpisCZFICBGxVXdHWjUDgSvuQKjnO9acNcXR1+68IU08iX+cU6f2kq6VzI4mW/pNieI20FDFbx9KA0YZ4+A==",
+      "dependencies": {
+        "@sentry/core": "7.36.0",
+        "@sentry/replay": "7.36.0",
+        "@sentry/types": "7.36.0",
+        "@sentry/utils": "7.36.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.36.0.tgz",
+      "integrity": "sha512-lq1MlcMhvm7QIwUOknFeufkg4M6QREY3s61y6pm1o+o3vSqB7Hz0D19xlyEpP62qMn8OyuttVKOVK1UfGc2EyQ==",
+      "dependencies": {
+        "@sentry/types": "7.36.0",
+        "@sentry/utils": "7.36.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/replay": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.36.0.tgz",
+      "integrity": "sha512-wNbME74/2GtkqdDXz7NaStyfPWVLjYmN9TFWvu6E9sNl9pkDDvii/Qc8F6ps1wa7bozkKcWRHgNvYiGCxUBHcg==",
+      "dependencies": {
+        "@sentry/core": "7.36.0",
+        "@sentry/types": "7.36.0",
+        "@sentry/utils": "7.36.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.36.0.tgz",
+      "integrity": "sha512-5R5mfWMDncOcTMmmyYMjgus1vZJzIFw4LHaSbrX7e1IRNT/6vFyNeVxATa2ePXb9mI3XHo5f2p7YrnreAtaSXw==",
+      "dependencies": {
+        "@sentry/core": "7.36.0",
+        "@sentry/types": "7.36.0",
+        "@sentry/utils": "7.36.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.36.0.tgz",
+      "integrity": "sha512-uvfwUn3okAWSZ948D/xqBrkc3Sn6TeHUgi3+p/dTTNGAXXskzavgfgQ4rSW7f3YD4LL+boZojpoIARVLodMGuA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.36.0.tgz",
+      "integrity": "sha512-mgDi5X5Bm0sydCzXpnyKD/sD98yc2qnKXyRdNX4HRRwruhC/P53LT0hGhZXsyqsB/l8OAMl0zWXJLg0xONQsEw==",
+      "dependencies": {
+        "@sentry/types": "7.36.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/vue": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.36.0.tgz",
+      "integrity": "sha512-GeGuHZimT/zlbWALx9rlT4N7Nvatfoi8HGFQNNlNG/WHNBjPrhPD5O/+54IM1es19wH1Yqdbne8D0O5mk4MAyg==",
+      "dependencies": {
+        "@sentry/browser": "7.36.0",
+        "@sentry/core": "7.36.0",
+        "@sentry/types": "7.36.0",
+        "@sentry/utils": "7.36.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "vue": "2.x || 3.x"
+      }
+    },
+    "node_modules/@sentry/vue/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@simonwep/pickr": {
       "version": "1.8.2",
@@ -16553,6 +16674,110 @@
       "requires": {
         "estree-walker": "^2.0.1",
         "picomatch": "^2.2.2"
+      }
+    },
+    "@sentry/browser": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.36.0.tgz",
+      "integrity": "sha512-Mu0OpisCZFICBGxVXdHWjUDgSvuQKjnO9acNcXR1+68IU08iX+cU6f2kq6VzI4mW/pNieI20FDFbx9KA0YZ4+A==",
+      "requires": {
+        "@sentry/core": "7.36.0",
+        "@sentry/replay": "7.36.0",
+        "@sentry/types": "7.36.0",
+        "@sentry/utils": "7.36.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/core": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.36.0.tgz",
+      "integrity": "sha512-lq1MlcMhvm7QIwUOknFeufkg4M6QREY3s61y6pm1o+o3vSqB7Hz0D19xlyEpP62qMn8OyuttVKOVK1UfGc2EyQ==",
+      "requires": {
+        "@sentry/types": "7.36.0",
+        "@sentry/utils": "7.36.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/replay": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.36.0.tgz",
+      "integrity": "sha512-wNbME74/2GtkqdDXz7NaStyfPWVLjYmN9TFWvu6E9sNl9pkDDvii/Qc8F6ps1wa7bozkKcWRHgNvYiGCxUBHcg==",
+      "requires": {
+        "@sentry/core": "7.36.0",
+        "@sentry/types": "7.36.0",
+        "@sentry/utils": "7.36.0"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.36.0.tgz",
+      "integrity": "sha512-5R5mfWMDncOcTMmmyYMjgus1vZJzIFw4LHaSbrX7e1IRNT/6vFyNeVxATa2ePXb9mI3XHo5f2p7YrnreAtaSXw==",
+      "requires": {
+        "@sentry/core": "7.36.0",
+        "@sentry/types": "7.36.0",
+        "@sentry/utils": "7.36.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.36.0.tgz",
+      "integrity": "sha512-uvfwUn3okAWSZ948D/xqBrkc3Sn6TeHUgi3+p/dTTNGAXXskzavgfgQ4rSW7f3YD4LL+boZojpoIARVLodMGuA=="
+    },
+    "@sentry/utils": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.36.0.tgz",
+      "integrity": "sha512-mgDi5X5Bm0sydCzXpnyKD/sD98yc2qnKXyRdNX4HRRwruhC/P53LT0hGhZXsyqsB/l8OAMl0zWXJLg0xONQsEw==",
+      "requires": {
+        "@sentry/types": "7.36.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/vue": {
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-7.36.0.tgz",
+      "integrity": "sha512-GeGuHZimT/zlbWALx9rlT4N7Nvatfoi8HGFQNNlNG/WHNBjPrhPD5O/+54IM1es19wH1Yqdbne8D0O5mk4MAyg==",
+      "requires": {
+        "@sentry/browser": "7.36.0",
+        "@sentry/core": "7.36.0",
+        "@sentry/types": "7.36.0",
+        "@sentry/utils": "7.36.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@simonwep/pickr": {

--- a/packages/nc-gui/package.json
+++ b/packages/nc-gui/package.json
@@ -32,6 +32,9 @@
   },
   "dependencies": {
     "@ckpack/vue-color": "^1.2.0",
+    "@sentry/browser": "^7.35.0",
+    "@sentry/tracing": "^7.35.0",
+    "@sentry/vue": "^7.35.0",
     "@vue-flow/additional-components": "^1.2.0",
     "@vue-flow/core": "^1.3.0",
     "@vuelidate/core": "^2.0.0-alpha.44",

--- a/packages/nc-gui/plugins/t.sentry.client.ts
+++ b/packages/nc-gui/plugins/t.sentry.client.ts
@@ -1,0 +1,48 @@
+import * as Sentry from '@sentry/vue'
+import { defineNuxtPlugin } from 'nuxt/app'
+import { useGlobal } from '~/composables/useGlobal'
+
+// https://localazy.com/blog/nuxt-3-tailwind-i18n-eslint-starter
+// https://github.com/nuxt-community/sentry-module/issues/358
+export default defineNuxtPlugin((nuxtApp) => {
+  const { vueApp } = nuxtApp
+  const { appInfo, user } = $(useGlobal())
+
+  if (!appInfo.sentryDsnFrontend || !appInfo.platform) {
+    return
+  }
+
+  Sentry.init({
+    app: [vueApp],
+    dsn: appInfo.sentryDsnFrontend,
+    release: appInfo.version,
+    environment: appInfo.platform,
+    attachStacktrace: true,
+    beforeSend(event, hint) {
+      if (event.exception && appInfo.platform === 'development') {
+        console.error(`[Exception handled by Sentry]: (${hint.originalException})`, { event, hint })
+      }
+      return event
+    },
+    initialScope: {
+      user: { id: user?.id, email: user?.email },
+    },
+    enabled: Boolean(appInfo.platform),
+  })
+
+  Sentry.attachErrorHandler(vueApp, {
+    logErrors: false,
+    attachProps: true,
+    trackComponents: true,
+    timeout: 2000,
+    hooks: ['activate', 'mount', 'update'],
+  })
+
+  return {
+    provide: {
+      sentrySetUser: Sentry.setUser,
+      sentryAddBreadcrumb: Sentry.addBreadcrumb,
+      sentryCaptureException: Sentry.captureException,
+    },
+  }
+})

--- a/packages/nc-gui/tsconfig.json
+++ b/packages/nc-gui/tsconfig.json
@@ -16,7 +16,8 @@
       "unplugin-icons/types/vue",
       "nuxt-windicss",
       "vite/client",
-      "@nuxt/image-edge"
+      "@nuxt/image-edge",
+      "@nuxtjs/sentry"
     ]
   },
   "exclude": [

--- a/packages/nocodb/package-lock.json
+++ b/packages/nocodb/package-lock.json
@@ -9756,7 +9756,7 @@
     "node_modules/nc-lib-gui": {
       "version": "0.100.1",
       "resolved": "file:nc-lib-gui-0.100.1.tgz",
-      "integrity": "sha512-oiBwzbbxoEdCrjRLb1ag1svn08aRnpCeRRdST4RLJZotzYz2iPlas8QcEFAe0S0UKP6F2v5+imF5yG2OrX1DMg==",
+      "integrity": "sha512-ySBU2zRKW1NjSVH7oe2FuIs8a2dT2mnqVsmRfExpbUU+VT1rRrnQYr+aDpQzqa4iHc9JWFkRXR5VYpHWrvGzhA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "express": "^4.17.1"
@@ -22880,7 +22880,7 @@
     },
     "nc-lib-gui": {
       "version": "file:nc-lib-gui-0.100.1.tgz",
-      "integrity": "sha512-oiBwzbbxoEdCrjRLb1ag1svn08aRnpCeRRdST4RLJZotzYz2iPlas8QcEFAe0S0UKP6F2v5+imF5yG2OrX1DMg==",
+      "integrity": "sha512-ySBU2zRKW1NjSVH7oe2FuIs8a2dT2mnqVsmRfExpbUU+VT1rRrnQYr+aDpQzqa4iHc9JWFkRXR5VYpHWrvGzhA==",
       "requires": {
         "express": "^4.17.1"
       }

--- a/packages/nocodb/src/lib/Noco.ts
+++ b/packages/nocodb/src/lib/Noco.ts
@@ -284,7 +284,10 @@ export default class Noco {
 
   private initSentry() {
     if (process.env.NC_SENTRY_DSN) {
-      Sentry.init({ dsn: process.env.NC_SENTRY_DSN });
+      Sentry.init({
+        dsn: process.env.NC_SENTRY_DSN,
+        environment: process.env.NC_ENV,
+      });
 
       // The request handler must be the first middleware on the app
       this.router.use(Sentry.Handlers.requestHandler());

--- a/packages/nocodb/src/lib/meta/api/utilApis.ts
+++ b/packages/nocodb/src/lib/meta/api/utilApis.ts
@@ -58,6 +58,8 @@ export async function appInfo(req: Request, res: Response) {
     teleEnabled: !process.env.NC_DISABLE_TELE,
     noSignUp: process.env.NC_NO_SIGN_UP === '1',
     ncSiteUrl: (req as any).ncSiteUrl,
+    platform: process.env.NC_ENV,
+    sentryDsnFrontend: process.env.NC_SENTRY_DSN_FRONTEND,
   };
 
   res.json(result);

--- a/packages/nocodb/src/lib/meta/helpers/catchError.ts
+++ b/packages/nocodb/src/lib/meta/helpers/catchError.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/node';
+
 export default function (
   requestHandler: (req: any, res: any, next?: any) => any
 ) {
@@ -7,6 +9,8 @@ export default function (
     } catch (e) {
       // todo: error log
       console.log(requestHandler.name ? `${requestHandler.name} ::` : '', e);
+
+      Sentry.captureException(e);
 
       if (e instanceof BadRequest) {
         return res.status(400).json({ msg: e.message });


### PR DESCRIPTION
## Change Summary

Add Sentry to frontend + a couple of additional data to events on backend
The first idea was to use sentry-vite-plugin to create releases and update artefacts, but I don't see any pros for this solution over directly downloading maps from website, so sentry ips were just added to whitelist in aws
 
## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
