### PR TITLE
throw 400 instead of 500 for failed requests

### DIFF
--- a/packages/nocodb/src/lib/meta/api/dataApis/dataAliasApis.ts
+++ b/packages/nocodb/src/lib/meta/api/dataApis/dataAliasApis.ts
@@ -135,8 +135,8 @@ async function getDataList(model, view: View, req) {
     count = await baseModel.count(listArgs);
   } catch (e) {
     console.log(e);
-    NcError.internalServerError(
-      'Internal Server Error, check server log for more details'
+    NcError.badRequest(
+      e.message || 'Error while executing the query. Please check the request.'
     );
   }
 


### PR DESCRIPTION
## Change Summary

Backed is throwing 500s for invalid data in filters which is wrong and resulting in too many alerts in slack channel.
This PR is fixing it.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
